### PR TITLE
Enter prerelease mode

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -24,7 +24,7 @@ jobs:
                   installer-parallel: true
 
             - name: Bump version
-              run: poetry version patch
+              run: poetry version prerelease
 
             - name: Get version
               id: get-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 
 [tool.poetry]
 name = "neo4j-genai"
-version = "1.0.0a0"
+version = "0.2.0a0"
 description = "Python package to allow easy integration to Neo4j's GenAI features"
 authors = ["Neo4j, Inc <team-gen-ai@neo4j.com>"]
 license = "Apache License, Version 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 
 [tool.poetry]
 name = "neo4j-genai"
-version = "0.1.4"
+version = "1.0.0a0"
 description = "Python package to allow easy integration to Neo4j's GenAI features"
 authors = ["Neo4j, Inc <team-gen-ai@neo4j.com>"]
 license = "Apache License, Version 2.0"


### PR DESCRIPTION
We're now releasing `0.1.X` versions that might (will) have breaking changes, which is not desired from a developers point of view.
This PR takes the package into prerelease mode (`0.2.0a0`), to signal that breaking changes might happen at any time.