### PR TITLE
Add debug logging in retrievers

### DIFF
--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -86,8 +86,8 @@ class HybridRetriever(Retriever):
 
         search_query = get_search_query(SearchType.HYBRID, self.return_properties)
 
-        logger.debug("HybridRetriever Cypher parameters", parameters)
-        logger.debug("HybridRetriever Cypher query", search_query)
+        logger.debug("HybridRetriever Cypher parameters %s", parameters)
+        logger.debug("HybridRetriever Cypher query %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records
@@ -164,8 +164,8 @@ class HybridCypherRetriever(Retriever):
             SearchType.HYBRID, retrieval_query=self.retrieval_query
         )
 
-        logger.debug("HybridCypherRetriever Cypher parameters", parameters)
-        logger.debug("HybridCypherRetriever Cypher query", search_query)
+        logger.debug("HybridCypherRetriever Cypher parameters %s", parameters)
+        logger.debug("HybridCypherRetriever Cypher query %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -22,7 +22,6 @@ from neo4j_genai.retrievers.base import Retriever
 from neo4j_genai.types import HybridSearchModel, SearchType, HybridCypherSearchModel
 from neo4j_genai.neo4j_queries import get_search_query
 import logging
-import json
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +86,8 @@ class HybridRetriever(Retriever):
 
         search_query = get_search_query(SearchType.HYBRID, self.return_properties)
 
-        logger.debug(f"HybridRetriever Cypher parameters: {json.dumps(parameters)}")
-        logger.debug(f"HybridRetriever Cypher query: {search_query}")
+        logger.debug("HybridRetriever Cypher parameters", parameters)
+        logger.debug("HybridRetriever Cypher query", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records
@@ -165,10 +164,8 @@ class HybridCypherRetriever(Retriever):
             SearchType.HYBRID, retrieval_query=self.retrieval_query
         )
 
-        logger.debug(
-            f"HybridCypherRetriever Cypher parameters: {json.dumps(parameters)}"
-        )
-        logger.debug(f"HybridCypherRetriever Cypher query: {search_query}")
+        logger.debug("HybridCypherRetriever Cypher parameters", parameters)
+        logger.debug("HybridCypherRetriever Cypher query", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -86,8 +86,8 @@ class HybridRetriever(Retriever):
 
         search_query = get_search_query(SearchType.HYBRID, self.return_properties)
 
-        logger.debug("HybridRetriever Cypher parameters %s", parameters)
-        logger.debug("HybridRetriever Cypher query %s", search_query)
+        logger.debug("HybridRetriever Cypher parameters: %s", parameters)
+        logger.debug("HybridRetriever Cypher query: %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records
@@ -164,8 +164,8 @@ class HybridCypherRetriever(Retriever):
             SearchType.HYBRID, retrieval_query=self.retrieval_query
         )
 
-        logger.debug("HybridCypherRetriever Cypher parameters %s", parameters)
-        logger.debug("HybridCypherRetriever Cypher query %s", search_query)
+        logger.debug("HybridCypherRetriever Cypher parameters: %s", parameters)
+        logger.debug("HybridCypherRetriever Cypher query: %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -21,6 +21,10 @@ from neo4j_genai.embedder import Embedder
 from neo4j_genai.retrievers.base import Retriever
 from neo4j_genai.types import HybridSearchModel, SearchType, HybridCypherSearchModel
 from neo4j_genai.neo4j_queries import get_search_query
+import logging
+import json
+
+logger = logging.getLogger(__name__)
 
 
 class HybridRetriever(Retriever):
@@ -82,6 +86,9 @@ class HybridRetriever(Retriever):
             parameters["query_vector"] = query_vector
 
         search_query = get_search_query(SearchType.HYBRID, self.return_properties)
+
+        logger.debug(f"HybridRetriever Cypher parameters: {json.dumps(parameters)}")
+        logger.debug(f"HybridRetriever Cypher query: {search_query}")
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records
@@ -157,5 +164,11 @@ class HybridCypherRetriever(Retriever):
         search_query = get_search_query(
             SearchType.HYBRID, retrieval_query=self.retrieval_query
         )
+
+        logger.debug(
+            f"HybridCypherRetriever Cypher parameters: {json.dumps(parameters)}"
+        )
+        logger.debug(f"HybridCypherRetriever Cypher query: {search_query}")
+
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -26,6 +26,10 @@ from neo4j_genai.types import (
     SearchType,
 )
 from neo4j_genai.neo4j_queries import get_search_query
+import logging
+import json
+
+logger = logging.getLogger(__name__)
 
 
 class VectorRetriever(Retriever):
@@ -91,6 +95,9 @@ class VectorRetriever(Retriever):
             del parameters["query_text"]
 
         search_query = get_search_query(SearchType.VECTOR, self.return_properties)
+
+        logger.debug(f"VectorRetriever Cypher parameters: {json.dumps(parameters)}")
+        logger.debug(f"VectorRetriever Cypher query: {search_query}")
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
 
@@ -178,5 +185,11 @@ class VectorCypherRetriever(Retriever):
         search_query = get_search_query(
             SearchType.VECTOR, retrieval_query=self.retrieval_query
         )
+
+        logger.debug(
+            f"VectorCypherRetriever Cypher parameters: {json.dumps(parameters)}"
+        )
+        logger.debug(f"VectorCypherRetriever Cypher query: {search_query}")
+
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -95,8 +95,8 @@ class VectorRetriever(Retriever):
 
         search_query = get_search_query(SearchType.VECTOR, self.return_properties)
 
-        logger.debug("VectorRetriever Cypher parameters %s", parameters)
-        logger.debug("VectorRetriever Cypher query %s", search_query)
+        logger.debug("VectorRetriever Cypher parameters: %s", parameters)
+        logger.debug("VectorRetriever Cypher query: %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
 
@@ -185,8 +185,8 @@ class VectorCypherRetriever(Retriever):
             SearchType.VECTOR, retrieval_query=self.retrieval_query
         )
 
-        logger.debug("VectorCypherRetriever Cypher parameters %s", parameters)
-        logger.debug("VectorCypherRetriever Cypher query %s", search_query)
+        logger.debug("VectorCypherRetriever Cypher parameters: %s", parameters)
+        logger.debug("VectorCypherRetriever Cypher query: %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -27,7 +27,6 @@ from neo4j_genai.types import (
 )
 from neo4j_genai.neo4j_queries import get_search_query
 import logging
-import json
 
 logger = logging.getLogger(__name__)
 
@@ -96,8 +95,8 @@ class VectorRetriever(Retriever):
 
         search_query = get_search_query(SearchType.VECTOR, self.return_properties)
 
-        logger.debug(f"VectorRetriever Cypher parameters: {json.dumps(parameters)}")
-        logger.debug(f"VectorRetriever Cypher query: {search_query}")
+        logger.debug("VectorRetriever Cypher parameters", parameters)
+        logger.debug("VectorRetriever Cypher query", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
 
@@ -186,10 +185,8 @@ class VectorCypherRetriever(Retriever):
             SearchType.VECTOR, retrieval_query=self.retrieval_query
         )
 
-        logger.debug(
-            f"VectorCypherRetriever Cypher parameters: {json.dumps(parameters)}"
-        )
-        logger.debug(f"VectorCypherRetriever Cypher query: {search_query}")
+        logger.debug("VectorCypherRetriever Cypher parameters", parameters)
+        logger.debug("VectorCypherRetriever Cypher query", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -95,8 +95,8 @@ class VectorRetriever(Retriever):
 
         search_query = get_search_query(SearchType.VECTOR, self.return_properties)
 
-        logger.debug("VectorRetriever Cypher parameters", parameters)
-        logger.debug("VectorRetriever Cypher query", search_query)
+        logger.debug("VectorRetriever Cypher parameters %s", parameters)
+        logger.debug("VectorRetriever Cypher query %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
 
@@ -185,8 +185,8 @@ class VectorCypherRetriever(Retriever):
             SearchType.VECTOR, retrieval_query=self.retrieval_query
         )
 
-        logger.debug("VectorCypherRetriever Cypher parameters", parameters)
-        logger.debug("VectorCypherRetriever Cypher query", search_query)
+        logger.debug("VectorCypherRetriever Cypher parameters %s", parameters)
+        logger.debug("VectorCypherRetriever Cypher query %s", search_query)
 
         records, _, _ = self.driver.execute_query(search_query, parameters)
         return records


### PR DESCRIPTION
We do not set any basic config on the loggers, but leave that for application developers to keep the log format consistent with their existing ones.

This can be tested by logging `DEBUG` when running tests:

```bash
poetry run pytest tests/unit --log-cli-level=DEBUG
```