### PR TITLE
Handle failure cases for index handling methods

### DIFF
--- a/src/neo4j_genai/retrievers/base.py
+++ b/src/neo4j_genai/retrievers/base.py
@@ -15,7 +15,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-from neo4j import Driver
+import neo4j
 
 
 class Retriever(ABC):
@@ -23,7 +23,7 @@ class Retriever(ABC):
     Abstract class for Neo4j retrievers
     """
 
-    def __init__(self, driver: Driver):
+    def __init__(self, driver: neo4j.Driver):
         self.driver = driver
         self._verify_version()
 

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from typing import Optional, Any
 
-from neo4j import Record, Driver
+import neo4j
 from pydantic import ValidationError
 
 from neo4j_genai.embedder import Embedder
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 class HybridRetriever(Retriever):
     def __init__(
         self,
-        driver: Driver,
+        driver: neo4j.Driver,
         vector_index_name: str,
         fulltext_index_name: str,
         embedder: Optional[Embedder] = None,
@@ -46,7 +46,7 @@ class HybridRetriever(Retriever):
         query_text: str,
         query_vector: Optional[list[float]] = None,
         top_k: int = 5,
-    ) -> list[Record]:
+    ) -> list[neo4j.Record]:
         """Get the top_k nearest neighbor embeddings for either provided query_vector or query_text.
         Both query_vector and query_text can be provided.
         If query_vector is provided, then it will be preferred over the embedded query_text
@@ -63,7 +63,7 @@ class HybridRetriever(Retriever):
             ValueError: If validation of the input arguments fail.
             ValueError: If no embedder is provided.
         Returns:
-            list[Record]: The results of the search query
+            list[neo4j.Record]: The results of the search query
         """
         try:
             validated_data = HybridSearchModel(
@@ -96,7 +96,7 @@ class HybridRetriever(Retriever):
 class HybridCypherRetriever(Retriever):
     def __init__(
         self,
-        driver: Driver,
+        driver: neo4j.Driver,
         vector_index_name: str,
         fulltext_index_name: str,
         retrieval_query: str,
@@ -114,7 +114,7 @@ class HybridCypherRetriever(Retriever):
         query_vector: Optional[list[float]] = None,
         top_k: int = 5,
         query_params: Optional[dict[str, Any]] = None,
-    ) -> list[Record]:
+    ) -> list[neo4j.Record]:
         """Get the top_k nearest neighbor embeddings for either provided query_vector or query_text.
         Both query_vector and query_text can be provided.
         If query_vector is provided, then it will be preferred over the embedded query_text
@@ -132,7 +132,7 @@ class HybridCypherRetriever(Retriever):
             ValueError: If validation of the input arguments fail.
             ValueError: If no embedder is provided.
         Returns:
-            list[Record]: The results of the search query
+            list[neo4j.Record]: The results of the search query
         """
         try:
             validated_data = HybridCypherSearchModel(

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from typing import Optional, Any
 
-from neo4j import Driver, Record
+import neo4j
 from neo4j_genai.retrievers.base import Retriever
 from pydantic import ValidationError
 
@@ -39,7 +39,7 @@ class VectorRetriever(Retriever):
 
     def __init__(
         self,
-        driver: Driver,
+        driver: neo4j.Driver,
         index_name: str,
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
@@ -120,7 +120,7 @@ class VectorCypherRetriever(Retriever):
 
     def __init__(
         self,
-        driver: Driver,
+        driver: neo4j.Driver,
         index_name: str,
         retrieval_query: str,
         embedder: Optional[Embedder] = None,
@@ -136,7 +136,7 @@ class VectorCypherRetriever(Retriever):
         query_text: Optional[str] = None,
         top_k: int = 5,
         query_params: Optional[dict[str, Any]] = None,
-    ) -> list[Record]:
+    ) -> list[neo4j.Record]:
         """Get the top_k nearest neighbor embeddings for either provided query_vector or query_text.
         See the following documentation for more details:
 
@@ -154,7 +154,7 @@ class VectorCypherRetriever(Retriever):
             ValueError: If no embedder is provided.
 
         Returns:
-            list[Record]: The results of the search query
+            list[neo4j.Record]: The results of the search query
         """
         try:
             validated_data = VectorCypherSearchModel(

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -15,7 +15,7 @@
 from enum import Enum
 from typing import Any, Literal, Optional
 from pydantic import BaseModel, PositiveInt, model_validator, field_validator
-from neo4j import Driver
+import neo4j
 
 
 class VectorSearchRecord(BaseModel):
@@ -28,7 +28,7 @@ class IndexModel(BaseModel):
 
     @field_validator("driver")
     def check_driver_is_valid(cls, v):
-        if not isinstance(v, Driver):
+        if not isinstance(v, neo4j.Driver):
             raise ValueError("driver must be an instance of neo4j.Driver")
         return v
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -19,7 +19,11 @@ import uuid
 import pytest
 from neo4j import GraphDatabase
 from neo4j_genai.embedder import Embedder
-from neo4j_genai.indexes import drop_index, create_vector_index, create_fulltext_index
+from neo4j_genai.indexes import (
+    drop_index_if_exists,
+    create_vector_index,
+    create_fulltext_index,
+)
 
 
 @pytest.fixture(scope="module")
@@ -47,8 +51,8 @@ def setup_neo4j(driver):
 
     # Delete data and drop indexes to prevent data leakage
     driver.execute_query("MATCH (n) DETACH DELETE n")
-    drop_index(driver, vector_index_name)
-    drop_index(driver, fulltext_index_name)
+    drop_index_if_exists(driver, vector_index_name)
+    drop_index_if_exists(driver, fulltext_index_name)
 
     # Create a vector index
     create_vector_index(

--- a/tests/e2e/test_hybrid_e2e.py
+++ b/tests/e2e/test_hybrid_e2e.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from neo4j import Record
+import neo4j
 
 from neo4j_genai import (
     HybridRetriever,
@@ -36,7 +36,7 @@ def test_hybrid_retriever_search_text(driver, custom_embedder):
     assert isinstance(results, list)
     assert len(results) == 5
     for result in results:
-        assert isinstance(result, Record)
+        assert isinstance(result, neo4j.Record)
 
 
 @pytest.mark.usefixtures("setup_neo4j")
@@ -58,7 +58,7 @@ def test_hybrid_cypher_retriever_search_text(driver, custom_embedder):
     assert isinstance(results, list)
     assert len(results) == 5
     for record in results:
-        assert isinstance(record, Record)
+        assert isinstance(record, neo4j.Record)
         assert "author.name" in record.keys()
 
 
@@ -80,7 +80,7 @@ def test_hybrid_retriever_search_vector(driver):
     assert isinstance(results, list)
     assert len(results) == 5
     for result in results:
-        assert isinstance(result, Record)
+        assert isinstance(result, neo4j.Record)
 
 
 @pytest.mark.usefixtures("setup_neo4j")
@@ -105,7 +105,7 @@ def test_hybrid_cypher_retriever_search_vector(driver):
     assert isinstance(results, list)
     assert len(results) == 5
     for record in results:
-        assert isinstance(record, Record)
+        assert isinstance(record, neo4j.Record)
         assert "author.name" in record.keys()
 
 
@@ -129,4 +129,4 @@ def test_hybrid_retriever_return_properties(driver):
     assert isinstance(results, list)
     assert len(results) == 5
     for result in results:
-        assert isinstance(result, Record)
+        assert isinstance(result, neo4j.Record)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,14 +14,14 @@
 #  limitations under the License.
 
 import pytest
+import neo4j
 from neo4j_genai import VectorRetriever, VectorCypherRetriever, HybridRetriever
-from neo4j import Driver
 from unittest.mock import MagicMock, patch
 
 
 @pytest.fixture(scope="function")
 def driver():
-    return MagicMock(spec=Driver)
+    return MagicMock(spec=neo4j.Driver)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Summary
- Adds try/catch for `create_vector_index`, `create_fulltext_index`, and `drop_index_if_exists`
- Rename `drop_index` to `drop_index_if_exists` as this is more true to its functionality
- Adds tests to assert that `neo4j.exceptions.ClientError` is raised successfully
- Adds logging for index handling methods
- Rename imports of `neo4j.Record` and `neo4j.Driver` to be more explicit