### PR TITLE
Fixed tests to raise correct error for retriever instantiation data validation

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,10 +18,17 @@ import neo4j
 from neo4j_genai import VectorRetriever, VectorCypherRetriever, HybridRetriever
 from unittest.mock import MagicMock, patch
 
+from neo4j_genai.embedder import Embedder
+
 
 @pytest.fixture(scope="function")
 def driver():
     return MagicMock(spec=neo4j.Driver)
+
+
+@pytest.fixture(scope="function")
+def embedder():
+    return MagicMock(spec=Embedder)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# Description
Previously the tests for testing incorrect data validation were wrong as they raised the wrong `ValueError`. They raised errors because `_verify_version` failed. This PR ensures the tests are set up correctly using `@patch` and additional assertions are added to the tests.

# Implementation Details
- Setup for `_verify_version` added for data validation tests. These would have failed and raised a `ValueError`, so more assertions are added to ensure the correct input argument fails the data validation
- Data validation test names made more descriptive
- `embedder` fixture added for unit tests
