### PR TITLE
Fix a typo in the E2E fixture name

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -114,7 +114,7 @@ def setup_neo4j_for_schema_query(driver):
 
 
 @pytest.fixture(scope="module")
-def ssetup_neo4j_for_schema_query_with_excluded_labels(driver):
+def setup_neo4j_for_schema_query_with_excluded_labels(driver):
     # Delete all nodes in the graph
     driver.execute_query("MATCH (n) DETACH DELETE n")
     # Create two labels and a relationship to be excluded

--- a/tests/e2e/test_schema_e2e.py
+++ b/tests/e2e/test_schema_e2e.py
@@ -78,7 +78,7 @@ def test_cypher_returns_correct_relationships(driver):
     )
 
 
-@pytest.mark.usefixtures("ssetup_neo4j_for_schema_query_with_excluded_labels")
+@pytest.mark.usefixtures("setup_neo4j_for_schema_query_with_excluded_labels")
 def test_filtering_labels_node_properties(driver):
     node_properties = [
         data["output"]
@@ -92,8 +92,8 @@ def test_filtering_labels_node_properties(driver):
     assert node_properties == []
 
 
-@pytest.mark.usefixtures("ssetup_neo4j_for_schema_query_with_excluded_labels")
-def test_get_schema_filtering_labels_relationship_properties(driver):
+@pytest.mark.usefixtures("setup_neo4j_for_schema_query_with_excluded_labels")
+def test_filtering_labels_relationship_properties(driver):
     relationship_properties = [
         data["output"]
         for data in query_database(
@@ -104,7 +104,7 @@ def test_get_schema_filtering_labels_relationship_properties(driver):
     assert relationship_properties == []
 
 
-@pytest.mark.usefixtures("ssetup_neo4j_for_schema_query_with_excluded_labels")
+@pytest.mark.usefixtures("setup_neo4j_for_schema_query_with_excluded_labels")
 def test_filtering_labels_relationships(driver):
     relationships = [
         data["output"]


### PR DESCRIPTION
# Description

Fixed a typo in the E2E fixture name.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
