### PR TITLE
Fix for flaky E2E test (take 2)

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Wait for Weaviate to start
         shell: bash
         run: |
-          count=0; until curl -s --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 10 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
+          count=0; until curl -v --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 10 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Wait for Weaviate to start
         shell: bash
         run: |
+          set +e
           count=0; until curl -v --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 10 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
       - name: Run tests
         shell: bash

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          count=0; until curl -s --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 15 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
+          count=0; until curl -s --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 10 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
       - name: Run tests
         shell: bash
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          count=0; until curl -v --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 10 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
+          count=0; until curl -s --fail localhost:8080/v1/.well-known/ready; do ((count++)); [ $count -ge 15 ] && echo "Reached maximum retry limit" && exit 1; sleep 15; done
       - name: Run tests
         shell: bash
         run: |


### PR DESCRIPTION
This time we're explicitly setting the bash +e flag to stop the fail-fast behaviour. 