### PR TITLE
Stopped the embedding from being returned with VectorRetriever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 -   New return types that help with getting retriever results: `RetrieverResult` and `RetrieverResultItem`.
 -   Supported wrapper embedder object for sentence-transformers embeddings: `SentenceTransformerEmbeddings`.
 -   `Text2CypherRetriever` object which allows for the retrieval of records from a Neo4j database using natural language.
+-   Stopped embeddings from being returned when searching with `VectorRetriever`. Added `nodeLabels` and `id` to the metadata of `VectorRetriever` results.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+### Added
+-   Stopped embeddings from being returned when searching with `VectorRetriever`. Added `nodeLabels` and `id` to the metadata of `VectorRetriever` results.
+
 ## 0.2.0
 
 ### Fixed
@@ -19,7 +22,6 @@
 -   New return types that help with getting retriever results: `RetrieverResult` and `RetrieverResultItem`.
 -   Supported wrapper embedder object for sentence-transformers embeddings: `SentenceTransformerEmbeddings`.
 -   `Text2CypherRetriever` object which allows for the retrieval of records from a Neo4j database using natural language.
--   Stopped embeddings from being returned when searching with `VectorRetriever`. Added `nodeLabels` and `id` to the metadata of `VectorRetriever` results.
 
 ### Changed
 

--- a/src/neo4j_genai/neo4j_queries.py
+++ b/src/neo4j_genai/neo4j_queries.py
@@ -147,7 +147,9 @@ def get_search_query(
     else:
         raise ValueError(f"Search type is not supported: {search_type}")
     query_tail = get_query_tail(
-        retrieval_query, return_properties, fallback_return="RETURN node, score"
+        retrieval_query,
+        return_properties,
+        fallback_return=f"RETURN apoc.map.removeKeys(node, ['{embedding_node_property}']) AS node, score",
     )
     return f"{query} {query_tail}", params
 

--- a/src/neo4j_genai/neo4j_queries.py
+++ b/src/neo4j_genai/neo4j_queries.py
@@ -149,7 +149,7 @@ def get_search_query(
     query_tail = get_query_tail(
         retrieval_query,
         return_properties,
-        fallback_return=f"RETURN apoc.map.removeKeys(node, ['{embedding_node_property}']) AS node, score",
+        fallback_return=f"RETURN node {{ .*, `{embedding_node_property}`: null }} AS node, score",
     )
     return f"{query} {query_tail}", params
 

--- a/src/neo4j_genai/neo4j_queries.py
+++ b/src/neo4j_genai/neo4j_queries.py
@@ -149,7 +149,7 @@ def get_search_query(
     query_tail = get_query_tail(
         retrieval_query,
         return_properties,
-        fallback_return=f"RETURN node {{ .*, _nodeLabels: labels(node), `{embedding_node_property}`: null }} AS node, score",
+        fallback_return=f"RETURN node {{ .*, `{embedding_node_property}`: null }} AS node, labels(node) AS nodeLabels, elementId(node) AS id, score",
     )
     return f"{query} {query_tail}", params
 

--- a/src/neo4j_genai/neo4j_queries.py
+++ b/src/neo4j_genai/neo4j_queries.py
@@ -149,7 +149,7 @@ def get_search_query(
     query_tail = get_query_tail(
         retrieval_query,
         return_properties,
-        fallback_return=f"RETURN node {{ .*, `{embedding_node_property}`: null }} AS node, score",
+        fallback_return=f"RETURN node {{ .*, _nodeLabels: labels(node), `{embedding_node_property}`: null }} AS node, score",
     )
     return f"{query} {query_tail}", params
 

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -108,6 +108,8 @@ class VectorRetriever(Retriever):
         """
         metadata = {
             "score": record.get("score"),
+            "nodeLabels": record.get("nodeLabels"),
+            "id": record.get("id"),
         }
         node = record.get("node")
         return RetrieverResultItem(

--- a/tests/e2e/test_vector_e2e.py
+++ b/tests/e2e/test_vector_e2e.py
@@ -32,6 +32,7 @@ def test_vector_retriever_search_text(
     assert isinstance(results, RetrieverResult)
     assert len(results.items) == 5
     for result in results.items:
+        assert retriever._embedding_node_property not in result.content
         assert isinstance(result, RetrieverResultItem)
 
 
@@ -66,6 +67,7 @@ def test_vector_retriever_search_vector(driver: Driver) -> None:
     assert isinstance(results, RetrieverResult)
     assert len(results.items) == 5
     for result in results.items:
+        assert retriever._embedding_node_property not in result.content
         assert isinstance(result, RetrieverResultItem)
 
 

--- a/tests/e2e/test_vector_e2e.py
+++ b/tests/e2e/test_vector_e2e.py
@@ -32,7 +32,7 @@ def test_vector_retriever_search_text(
     assert isinstance(results, RetrieverResult)
     assert len(results.items) == 5
     for result in results.items:
-        assert retriever._embedding_node_property not in result.content
+        assert f"'{retriever._embedding_node_property}': None" in result.content
         assert isinstance(result, RetrieverResultItem)
 
 
@@ -67,7 +67,7 @@ def test_vector_retriever_search_vector(driver: Driver) -> None:
     assert isinstance(results, RetrieverResult)
     assert len(results.items) == 5
     for result in results.items:
-        assert retriever._embedding_node_property not in result.content
+        assert f"'{retriever._embedding_node_property}': None" in result.content
         assert isinstance(result, RetrieverResultItem)
 
 

--- a/tests/unit/retrievers/test_vector.py
+++ b/tests/unit/retrievers/test_vector.py
@@ -101,7 +101,8 @@ def test_similarity_search_vector_happy_path(
     assert records == RetrieverResult(
         items=[
             RetrieverResultItem(
-                content="{'text': 'dummy-node'}", metadata={"score": 1.0}
+                content="{'text': 'dummy-node'}",
+                metadata={"score": 1.0, "nodeLabels": None, "id": None},
             ),
         ],
         metadata={"__retriever": "VectorRetriever"},
@@ -143,7 +144,10 @@ def test_similarity_search_text_happy_path(
     )
     assert records == RetrieverResult(
         items=[
-            RetrieverResultItem(content="dummy-node", metadata={"score": 1.0}),
+            RetrieverResultItem(
+                content="dummy-node",
+                metadata={"score": 1.0, "nodeLabels": None, "id": None},
+            ),
         ],
         metadata={"__retriever": "VectorRetriever"},
     )
@@ -191,7 +195,10 @@ def test_similarity_search_text_return_properties(
     )
     assert records == RetrieverResult(
         items=[
-            RetrieverResultItem(content="dummy-node", metadata={"score": 1.0}),
+            RetrieverResultItem(
+                content="dummy-node",
+                metadata={"score": 1.0, "nodeLabels": None, "id": None},
+            ),
         ],
         metadata={"__retriever": "VectorRetriever"},
     )

--- a/tests/unit/test_neo4j_queries.py
+++ b/tests/unit/test_neo4j_queries.py
@@ -22,7 +22,7 @@ def test_vector_search_basic() -> None:
     expected = (
         "CALL db.index.vector.queryNodes($vector_index_name, $top_k, $query_vector) "
         "YIELD node, score "
-        "RETURN apoc.map.removeKeys(node, ['None']) AS node, score"
+        "RETURN node { .*, `None`: null } AS node, score"
     )
     result, params = get_search_query(SearchType.VECTOR)
     assert result.strip() == expected.strip()
@@ -42,7 +42,7 @@ def test_hybrid_search_basic() -> None:
         "RETURN n.node AS node, (n.score / max) AS score "
         "} "
         "WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k "
-        "RETURN apoc.map.removeKeys(node, ['None']) AS node, score"
+        "RETURN node { .*, `None`: null } AS node, score"
     )
     result, _ = get_search_query(SearchType.HYBRID)
     assert result.strip() == expected.strip()
@@ -79,7 +79,7 @@ def test_vector_search_with_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN apoc.map.removeKeys(node, ['vector']) AS node, score"
+        "RETURN node { .*, `vector`: null } AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,
@@ -105,7 +105,7 @@ def test_vector_search_with_params_from_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN apoc.map.removeKeys(node, ['vector']) AS node, score"
+        "RETURN node { .*, `vector`: null } AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,

--- a/tests/unit/test_neo4j_queries.py
+++ b/tests/unit/test_neo4j_queries.py
@@ -22,7 +22,7 @@ def test_vector_search_basic() -> None:
     expected = (
         "CALL db.index.vector.queryNodes($vector_index_name, $top_k, $query_vector) "
         "YIELD node, score "
-        "RETURN node { .*, `None`: null } AS node, score"
+        "RETURN node { .*, _nodeLabels: labels(node), `None`: null } AS node, score"
     )
     result, params = get_search_query(SearchType.VECTOR)
     assert result.strip() == expected.strip()
@@ -42,7 +42,7 @@ def test_hybrid_search_basic() -> None:
         "RETURN n.node AS node, (n.score / max) AS score "
         "} "
         "WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, `None`: null } AS node, score"
+        "RETURN node { .*, _nodeLabels: labels(node), `None`: null } AS node, score"
     )
     result, _ = get_search_query(SearchType.HYBRID)
     assert result.strip() == expected.strip()
@@ -79,7 +79,7 @@ def test_vector_search_with_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, `vector`: null } AS node, score"
+        "RETURN node { .*, _nodeLabels: labels(node), `vector`: null } AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,
@@ -105,7 +105,7 @@ def test_vector_search_with_params_from_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, `vector`: null } AS node, score"
+        "RETURN node { .*, _nodeLabels: labels(node), `vector`: null } AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,

--- a/tests/unit/test_neo4j_queries.py
+++ b/tests/unit/test_neo4j_queries.py
@@ -22,7 +22,7 @@ def test_vector_search_basic() -> None:
     expected = (
         "CALL db.index.vector.queryNodes($vector_index_name, $top_k, $query_vector) "
         "YIELD node, score "
-        "RETURN node, score"
+        "RETURN apoc.map.removeKeys(node, ['None']) AS node, score"
     )
     result, params = get_search_query(SearchType.VECTOR)
     assert result.strip() == expected.strip()
@@ -42,7 +42,7 @@ def test_hybrid_search_basic() -> None:
         "RETURN n.node AS node, (n.score / max) AS score "
         "} "
         "WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k "
-        "RETURN node, score"
+        "RETURN apoc.map.removeKeys(node, ['None']) AS node, score"
     )
     result, _ = get_search_query(SearchType.HYBRID)
     assert result.strip() == expected.strip()
@@ -78,8 +78,8 @@ def test_vector_search_with_filters(_mock: Any) -> None:
         " AND (True) "
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
-        "ORDER BY score DESC LIMIT $top_k"
-        " RETURN node, score"
+        "ORDER BY score DESC LIMIT $top_k "
+        "RETURN apoc.map.removeKeys(node, ['vector']) AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,
@@ -104,8 +104,8 @@ def test_vector_search_with_params_from_filters(_mock: Any) -> None:
         " AND (True) "
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
-        "ORDER BY score DESC LIMIT $top_k"
-        " RETURN node, score"
+        "ORDER BY score DESC LIMIT $top_k "
+        "RETURN apoc.map.removeKeys(node, ['vector']) AS node, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,

--- a/tests/unit/test_neo4j_queries.py
+++ b/tests/unit/test_neo4j_queries.py
@@ -22,7 +22,7 @@ def test_vector_search_basic() -> None:
     expected = (
         "CALL db.index.vector.queryNodes($vector_index_name, $top_k, $query_vector) "
         "YIELD node, score "
-        "RETURN node { .*, _nodeLabels: labels(node), `None`: null } AS node, score"
+        "RETURN node { .*, `None`: null } AS node, labels(node) AS nodeLabels, elementId(node) AS id, score"
     )
     result, params = get_search_query(SearchType.VECTOR)
     assert result.strip() == expected.strip()
@@ -42,7 +42,7 @@ def test_hybrid_search_basic() -> None:
         "RETURN n.node AS node, (n.score / max) AS score "
         "} "
         "WITH node, max(score) AS score ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, _nodeLabels: labels(node), `None`: null } AS node, score"
+        "RETURN node { .*, `None`: null } AS node, labels(node) AS nodeLabels, elementId(node) AS id, score"
     )
     result, _ = get_search_query(SearchType.HYBRID)
     assert result.strip() == expected.strip()
@@ -79,7 +79,7 @@ def test_vector_search_with_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, _nodeLabels: labels(node), `vector`: null } AS node, score"
+        "RETURN node { .*, `vector`: null } AS node, labels(node) AS nodeLabels, elementId(node) AS id, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,
@@ -105,7 +105,7 @@ def test_vector_search_with_params_from_filters(_mock: Any) -> None:
         "WITH node, "
         "vector.similarity.cosine(node.`vector`, $query_vector) AS score "
         "ORDER BY score DESC LIMIT $top_k "
-        "RETURN node { .*, _nodeLabels: labels(node), `vector`: null } AS node, score"
+        "RETURN node { .*, `vector`: null } AS node, labels(node) AS nodeLabels, elementId(node) AS id, score"
     )
     result, params = get_search_query(
         SearchType.VECTOR,


### PR DESCRIPTION
# Description
Stops embeddings from being returned when searching with VectorRetriever

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Low

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [X] Unit tests have been updated
- [X] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
