### PR TITLE
Rename variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/build/
 .python-version
 .DS_Store
 .venv
+.tox/

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="textProperty",
+    embedding_property="vectorProperty",
     dimensions=1536,
     similarity_fn="euclidean",
 )
@@ -118,7 +118,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'textProperty', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="textProperty",
+    embedding_property="textProperty",
     dimensions=1536,
     similarity_fn="euclidean",
 )

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,14 +52,14 @@ This section includes retrievers that integrate with databases external to Neo4j
 WeaviateNeo4jRetriever
 ======================
 
-.. autoclass:: neo4j_genai.retrievers.external.weaviate.WeaviateNeo4jRetriever
+.. autoclass:: neo4j_genai.retrievers.external.weaviate.weaviate.WeaviateNeo4jRetriever
    :members:
 
 
 PineconeNeo4jRetriever
 ======================
 
-.. autoclass:: neo4j_genai.retrievers.external.pinecone.PineconeNeo4jRetriever
+.. autoclass:: neo4j_genai.retrievers.external.pinecone.pinecone.PineconeNeo4jRetriever
    :members:
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,7 +112,7 @@ When creating a vector index, make sure you match the number of dimensions in th
         driver,
         INDEX_NAME,
         label="Document",
-        embedding_property="textProperty",
+        embedding_property="vectorProperty",
         dimensions=1536,
         similarity_fn="euclidean",
     )
@@ -144,7 +144,7 @@ See below for how to write using Cypher via the Neo4j driver.
     insert_query = (
         "MERGE (n:Document {id: $id})"
         "WITH n "
-        "CALL db.create.setNodeVectorProperty(n, 'textProperty', $vector)"
+        "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
         "RETURN n"
     )
     parameters = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,7 +112,7 @@ When creating a vector index, make sure you match the number of dimensions in th
         driver,
         INDEX_NAME,
         label="Document",
-        property="textProperty",
+        embedding_property="textProperty",
         dimensions=1536,
         similarity_fn="euclidean",
     )

--- a/examples/graphrag.py
+++ b/examples/graphrag.py
@@ -44,7 +44,7 @@ retriever = VectorCypherRetriever(
     driver,
     index_name=INDEX,
     retrieval_query="with node, score return node.title as title, node.plot as plot",
-    format_record_function=formatter,
+    result_formatter=formatter,
     embedder=embedder,
 )
 

--- a/examples/graphrag_custom_prompt.py
+++ b/examples/graphrag_custom_prompt.py
@@ -45,7 +45,7 @@ retriever = VectorCypherRetriever(
     driver,
     index_name=INDEX,
     retrieval_query="with node, score return node.title as title, node.plot as plot",
-    format_record_function=formatter,
+    result_formatter=formatter,
     embedder=embedder,
 )
 

--- a/examples/hybrid_cypher_search.py
+++ b/examples/hybrid_cypher_search.py
@@ -29,12 +29,12 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
 create_fulltext_index(
-    driver, FULLTEXT_INDEX_NAME, label="Document", node_properties=["propertyKey"]
+    driver, FULLTEXT_INDEX_NAME, label="Document", node_properties=["vectorProperty"]
 )
 
 # Initialize the retriever
@@ -48,7 +48,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/examples/hybrid_cypher_search.py
+++ b/examples/hybrid_cypher_search.py
@@ -29,7 +29,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/hybrid_search.py
+++ b/examples/hybrid_search.py
@@ -29,12 +29,12 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
 create_fulltext_index(
-    driver, FULLTEXT_INDEX_NAME, label="Document", node_properties=["propertyKey"]
+    driver, FULLTEXT_INDEX_NAME, label="Document", node_properties=["vectorProperty"]
 )
 
 # Initialize the retriever
@@ -45,7 +45,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/examples/hybrid_search.py
+++ b/examples/hybrid_search.py
@@ -29,7 +29,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/openai_search.py
+++ b/examples/openai_search.py
@@ -27,7 +27,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="cosine",
 )

--- a/examples/openai_search.py
+++ b/examples/openai_search.py
@@ -27,7 +27,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="cosine",
 )
@@ -38,7 +38,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/examples/similarity_search_for_text.py
+++ b/examples/similarity_search_for_text.py
@@ -28,7 +28,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/similarity_search_for_text.py
+++ b/examples/similarity_search_for_text.py
@@ -28,7 +28,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
@@ -41,7 +41,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/examples/similarity_search_for_vector.py
+++ b/examples/similarity_search_for_vector.py
@@ -19,7 +19,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
@@ -32,7 +32,7 @@ vector = [random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (n:Document {id: $id})"
     "WITH n "
-    "CALL db.create.setNodeVectorProperty(n, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(n, 'vectorProperty', $vector)"
     "RETURN n"
 )
 parameters = {

--- a/examples/similarity_search_for_vector.py
+++ b/examples/similarity_search_for_vector.py
@@ -19,7 +19,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/vector_cypher_retrieval.py
+++ b/examples/vector_cypher_retrieval.py
@@ -35,7 +35,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/vector_cypher_retrieval.py
+++ b/examples/vector_cypher_retrieval.py
@@ -35,7 +35,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
@@ -49,7 +49,7 @@ vector = [random.random() for _ in range(DIMENSION)]
 insert_query = (
     "MERGE (doc:Document {id: $id})"
     "WITH doc "
-    "CALL db.create.setNodeVectorProperty(doc, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(doc, 'vectorProperty', $vector)"
     "WITH doc "
     "MERGE (author:Author {name: $authorName})"
     "MERGE (doc)-[:AUTHORED_BY]->(author)"

--- a/examples/vector_search_with_filters.py
+++ b/examples/vector_search_with_filters.py
@@ -35,7 +35,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    property="propertyKey",
+    embedding_property="propertyKey",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )

--- a/examples/vector_search_with_filters.py
+++ b/examples/vector_search_with_filters.py
@@ -35,7 +35,7 @@ create_vector_index(
     driver,
     INDEX_NAME,
     label="Document",
-    embedding_property="propertyKey",
+    embedding_property="vectorProperty",
     dimensions=DIMENSION,
     similarity_fn="euclidean",
 )
@@ -50,7 +50,7 @@ insert_query = (
     "ON CREATE SET  doc.int_property = $id, "
     "               doc.short_text_property = toString($id)"
     "WITH doc "
-    "CALL db.create.setNodeVectorProperty(doc, 'propertyKey', $vector)"
+    "CALL db.create.setNodeVectorProperty(doc, 'vectorProperty', $vector)"
     "WITH doc "
     "MERGE (author:Author {name: $authorName})"
     "MERGE (doc)-[:AUTHORED_BY]->(author)"

--- a/src/neo4j_genai/indexes.py
+++ b/src/neo4j_genai/indexes.py
@@ -29,7 +29,7 @@ def create_vector_index(
     driver: neo4j.Driver,
     name: str,
     label: str,
-    property: str,
+    embedding_property: str,
     dimensions: int,
     similarity_fn: Literal["euclidean", "cosine"],
 ) -> None:
@@ -46,7 +46,7 @@ def create_vector_index(
         driver (neo4j.Driver): Neo4j Python driver instance.
         name (str): The unique name of the index.
         label (str): The node label to be indexed.
-        property (str): The property key of a node which contains embedding values.
+        embedding_property (str): The property key of a node which contains embedding values.
         dimensions (int): Vector embedding dimension
         similarity_fn (str): case-insensitive values for the vector similarity function:
             ``euclidean`` or ``cosine``.
@@ -60,7 +60,7 @@ def create_vector_index(
             driver=driver,
             name=name,
             label=label,
-            property=property,
+            embedding_property=embedding_property,
             dimensions=dimensions,
             similarity_fn=similarity_fn,
         )
@@ -69,7 +69,7 @@ def create_vector_index(
 
     try:
         query = (
-            f"CREATE VECTOR INDEX $name FOR (n:{label}) ON n.{property} OPTIONS "
+            f"CREATE VECTOR INDEX $name FOR (n:{label}) ON n.{embedding_property} OPTIONS "
             "{ indexConfig: { `vector.dimensions`: toInteger($dimensions), `vector.similarity_function`: $similarity_fn } }"
         )
         logger.info(f"Creating vector index named '{name}'")
@@ -149,7 +149,7 @@ def drop_index_if_exists(driver: neo4j.Driver, name: str) -> None:
 def upsert_vector(
     driver: neo4j.Driver,
     node_id: int,
-    vector_prop: str,
+    embedding_property: str,
     vector: list[float],
 ) -> None:
     """
@@ -158,7 +158,7 @@ def upsert_vector(
     Args:
         driver (neo4j.Driver): Neo4j Python driver instance.
         node_id (int): The id of the node.
-        vector_prop (str): The name of the property to store the vector in.
+        embedding_property (str): The name of the property to store the vector in.
         vector (list[float]): The vector to store.
 
     Raises:
@@ -169,12 +169,12 @@ def upsert_vector(
         MATCH (n)
         WHERE elementId(n) = $id
         WITH n
-        CALL db.create.setNodeVectorProperty(n, $vector_prop, $vector)
+        CALL db.create.setNodeVectorProperty(n, $embedding_property, $vector)
         RETURN n
         """
         parameters = {
             "id": node_id,
-            "vector_prop": vector_prop,
+            "embedding_property": embedding_property,
             "vector": vector,
         }
         driver.execute_query(query, parameters)

--- a/src/neo4j_genai/retrievers/base.py
+++ b/src/neo4j_genai/retrievers/base.py
@@ -99,8 +99,8 @@ class Retriever(ABC):
         """
         Returns the function to use to transform a neo4j.Record to a RetrieverResultItem.
         """
-        if hasattr(self, "format_record_function"):
-            return self.format_record_function or self.default_format_record
+        if hasattr(self, "result_formatter"):
+            return self.result_formatter or self.default_format_record
         return self.default_format_record
 
     def default_format_record(self, record: neo4j.Record) -> RetrieverResultItem:

--- a/src/neo4j_genai/retrievers/base.py
+++ b/src/neo4j_genai/retrievers/base.py
@@ -100,10 +100,10 @@ class Retriever(ABC):
         Returns the function to use to transform a neo4j.Record to a RetrieverResultItem.
         """
         if hasattr(self, "result_formatter"):
-            return self.result_formatter or self.default_format_record
-        return self.default_format_record
+            return self.result_formatter or self.default_record_formatter
+        return self.default_record_formatter
 
-    def default_format_record(self, record: neo4j.Record) -> RetrieverResultItem:
+    def default_record_formatter(self, record: neo4j.Record) -> RetrieverResultItem:
         """
         Best effort to guess the node to text method. Inherited classes
         can override this method to implement custom text formatting.

--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -77,7 +77,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         id_property_neo4j (str): The name of the Neo4j node property that's used as the identifier for relating matches from Weaviate to Neo4j nodes.
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
-        format_record_function (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
 
     Raises:
         RetrieverInitializationError: If validation of the input arguments fail.
@@ -92,7 +92,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
         retrieval_query: Optional[str] = None,
-        format_record_function: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[Callable[[Any], Any]] = None,
     ):
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -106,7 +106,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
                 embedder_model=embedder_model,
                 return_properties=return_properties,
                 retrieval_query=retrieval_query,
-                format_record_function=format_record_function,
+                result_formatter=result_formatter,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors())
@@ -127,7 +127,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         )
         self.return_properties = validated_data.return_properties
         self.retrieval_query = validated_data.retrieval_query
-        self.format_record_function = validated_data.format_record_function
+        self.result_formatter = validated_data.result_formatter
 
     def _get_search_results(
         self,

--- a/src/neo4j_genai/retrievers/external/pinecone/types.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/types.py
@@ -48,4 +48,4 @@ class PineconeNeo4jRetrieverModel(BaseModel):
     embedder_model: Optional[EmbedderModel] = None
     return_properties: Optional[list[str]] = None
     retrieval_query: Optional[str] = None
-    format_record_function: Optional[Callable[[neo4j.Record], str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], str]] = None

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -51,7 +51,7 @@ class WeaviateNeo4jRetrieverModel(BaseModel):
     embedder_model: Optional[EmbedderModel]
     return_properties: Optional[list[str]] = None
     retrieval_query: Optional[str] = None
-    format_record_function: Optional[Callable[[neo4j.Record], str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], str]] = None
 
 
 class WeaviateNeo4jSearchModel(BaseModel):

--- a/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
@@ -68,7 +68,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         id_property_neo4j (str): The name of the Neo4j node property that's used as the identifier for relating matches from Weaviate to Neo4j nodes.
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
-        format_record_function (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
 
     Raises:
         RetrieverInitializationError: If validation of the input arguments fail.
@@ -84,7 +84,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
         retrieval_query: Optional[str] = None,
-        format_record_function: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[Callable[[Any], Any]] = None,
     ):
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -99,7 +99,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
                 embedder_model=embedder_model,
                 return_properties=return_properties,
                 retrieval_query=retrieval_query,
-                format_record_function=format_record_function,
+                result_formatter=result_formatter,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors())
@@ -115,7 +115,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         )
         self.return_properties = validated_data.return_properties
         self.retrieval_query = validated_data.retrieval_query
-        self.format_record_function = validated_data.format_record_function
+        self.result_formatter = validated_data.result_formatter
 
     def _get_search_results(
         self,

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -203,7 +203,7 @@ class HybridCypherRetriever(Retriever):
         fulltext_index_name (str): Fulltext index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        format_record_function (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
 
     Raises:
         RetrieverInitializationError: If validation of the input arguments fail.
@@ -216,7 +216,7 @@ class HybridCypherRetriever(Retriever):
         fulltext_index_name: str,
         retrieval_query: str,
         embedder: Optional[Embedder] = None,
-        format_record_function: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[Callable[[Any], Any]] = None,
     ) -> None:
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -240,7 +240,7 @@ class HybridCypherRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
-        self.format_record_function = format_record_function
+        self.result_formatter = result_formatter
 
     def _get_search_results(
         self,

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -100,7 +100,7 @@ class HybridRetriever(Retriever):
             else None
         )
 
-    def default_format_record(self, record: neo4j.Record) -> RetrieverResultItem:
+    def default_record_formatter(self, record: neo4j.Record) -> RetrieverResultItem:
         """
         Best effort to guess the node to text method. Inherited classes
         can override this method to implement custom text formatting.
@@ -203,7 +203,7 @@ class HybridCypherRetriever(Retriever):
         fulltext_index_name (str): Fulltext index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
 
     Raises:
         RetrieverInitializationError: If validation of the input arguments fail.

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -101,7 +101,7 @@ class VectorRetriever(Retriever):
         self._embedding_dimension = None
         self._fetch_index_infos()
 
-    def default_format_record(self, record: neo4j.Record) -> RetrieverResultItem:
+    def default_record_formatter(self, record: neo4j.Record) -> RetrieverResultItem:
         """
         Best effort to guess the node to text method. Inherited classes
         can override this method to implement custom text formatting.
@@ -207,7 +207,7 @@ class VectorCypherRetriever(Retriever):
         index_name (str): Vector index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
     """
 
     def __init__(

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -207,7 +207,7 @@ class VectorCypherRetriever(Retriever):
         index_name (str): Vector index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        format_record_function (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
     """
 
     def __init__(
@@ -216,7 +216,7 @@ class VectorCypherRetriever(Retriever):
         index_name: str,
         retrieval_query: str,
         embedder: Optional[Embedder] = None,
-        format_record_function: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[Callable[[Any], Any]] = None,
     ) -> None:
         try:
             driver_model = Neo4jDriverModel(driver=driver)
@@ -238,7 +238,7 @@ class VectorCypherRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
-        self.format_record_function = format_record_function
+        self.result_formatter = result_formatter
         self._node_label = None
         self._node_embedding_property = None
         self._embedding_dimension = None

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -97,7 +97,7 @@ class IndexModel(BaseModel):
 class VectorIndexModel(IndexModel):
     name: str
     label: str
-    property: str
+    embedding_property: str
     dimensions: PositiveInt
     similarity_fn: Literal["euclidean", "cosine"]
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -86,7 +86,7 @@ def setup_neo4j_for_retrieval(driver: Driver) -> None:
         driver,
         vector_index_name,
         label="Document",
-        property="propertyKey",
+        embedding_property="propertyKey",
         dimensions=1536,
         similarity_fn="euclidean",
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -86,14 +86,17 @@ def setup_neo4j_for_retrieval(driver: Driver) -> None:
         driver,
         vector_index_name,
         label="Document",
-        embedding_property="propertyKey",
+        embedding_property="vectorProperty",
         dimensions=1536,
         similarity_fn="euclidean",
     )
 
     # Create a fulltext index
     create_fulltext_index(
-        driver, fulltext_index_name, label="Document", node_properties=["propertyKey"]
+        driver,
+        fulltext_index_name,
+        label="Document",
+        node_properties=["vectorProperty"],
     )
 
     # Insert 10 vectors and authors
@@ -108,7 +111,7 @@ def setup_neo4j_for_retrieval(driver: Driver) -> None:
             "ON CREATE SET  doc.int_property = $i, "
             "               doc.short_text_property = toString($i)"
             "WITH doc "
-            "CALL db.create.setNodeVectorProperty(doc, 'propertyKey', $vector)"
+            "CALL db.create.setNodeVectorProperty(doc, 'vectorProperty', $vector)"
             "WITH doc "
             "MERGE (author:Author {name: $authorName})"
             "MERGE (doc)-[:AUTHORED_BY]->(author)"

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -457,7 +457,7 @@ def populate_neo4j(
             neo4j_driver,
             vector_index_name,
             label="Question",
-            property="vector",
+            embedding_property="vector",
             dimensions=384,
             similarity_fn="cosine",
         )

--- a/tests/unit/retrievers/test_hybrid.py
+++ b/tests/unit/retrievers/test_hybrid.py
@@ -26,7 +26,7 @@ def test_vector_retriever_initialization(driver: MagicMock) -> None:
     with patch("neo4j_genai.retrievers.base.Retriever._verify_version") as mock_verify:
         HybridRetriever(
             driver=driver,
-            vector_index_name="my-index",
+            vector_index_name="vector-index",
             fulltext_index_name="fulltext-index",
         )
         mock_verify.assert_called_once()
@@ -36,7 +36,7 @@ def test_vector_cypher_retriever_initialization(driver: MagicMock) -> None:
     with patch("neo4j_genai.retrievers.base.Retriever._verify_version") as mock_verify:
         HybridCypherRetriever(
             driver=driver,
-            vector_index_name="my-index",
+            vector_index_name="vector-index",
             fulltext_index_name="fulltext-index",
             retrieval_query="",
         )
@@ -50,7 +50,7 @@ def test_hybrid_retriever_invalid_fulltext_index_name(
     with pytest.raises(RetrieverInitializationError) as exc_info:
         HybridRetriever(
             driver=driver,
-            vector_index_name="my-index",
+            vector_index_name="vector-index",
             fulltext_index_name=42,  # type: ignore
         )
 
@@ -65,7 +65,7 @@ def test_hybrid_cypher_retriever_invalid_retrieval_query(
     with pytest.raises(RetrieverInitializationError) as exc_info:
         HybridCypherRetriever(
             driver=driver,
-            vector_index_name="my-index",
+            vector_index_name="vector-index",
             fulltext_index_name="fulltext-index",
             retrieval_query=42,  # type: ignore
         )
@@ -83,8 +83,8 @@ def test_hybrid_search_text_happy_path(
 ) -> None:
     embed_query_vector = [1.0 for _ in range(1536)]
     embedder.embed_query.return_value = embed_query_vector
-    vector_index_name = "my-index"
-    fulltext_index_name = "my-fulltext-index"
+    vector_index_name = "vector-index"
+    fulltext_index_name = "fulltext-index"
     query_text = "may thy knife chip and shatter"
     top_k = 5
 
@@ -130,8 +130,8 @@ def test_hybrid_search_favors_query_vector_over_embedding_vector(
     query_vector = [2.0 for _ in range(1536)]
 
     embedder.embed_query.return_value = embed_query_vector
-    vector_index_name = "my-index"
-    fulltext_index_name = "my-fulltext-index"
+    vector_index_name = "vector-index"
+    fulltext_index_name = "fulltext-index"
     query_text = "may thy knife chip and shatter"
     top_k = 5
     retriever = HybridRetriever(
@@ -198,8 +198,8 @@ def test_hybrid_retriever_return_properties(
 ) -> None:
     embed_query_vector = [1.0 for _ in range(1536)]
     embedder.embed_query.return_value = embed_query_vector
-    vector_index_name = "my-index"
-    fulltext_index_name = "my-fulltext-index"
+    vector_index_name = "vector-index"
+    fulltext_index_name = "fulltext-index"
     query_text = "may thy knife chip and shatter"
     top_k = 5
     return_properties = ["node-property-1", "node-property-2"]
@@ -247,8 +247,8 @@ def test_hybrid_cypher_retrieval_query_with_params(
 ) -> None:
     embed_query_vector = [1.0 for _ in range(1536)]
     embedder.embed_query.return_value = embed_query_vector
-    vector_index_name = "my-index"
-    fulltext_index_name = "my-fulltext-index"
+    vector_index_name = "vector-index"
+    fulltext_index_name = "fulltext-index"
     query_text = "may thy knife chip and shatter"
     top_k = 5
     retrieval_query = """

--- a/tests/unit/retrievers/test_vector.py
+++ b/tests/unit/retrievers/test_vector.py
@@ -344,7 +344,7 @@ def test_retrieval_query_with_result_format_function(
         index_name,
         retrieval_query,
         embedder=embedder,
-        format_record_function=format_function,
+        result_formatter=format_function,
     )
     query_text = "may thy knife chip and shatter"
     top_k = 5

--- a/tests/unit/test_indexes.py
+++ b/tests/unit/test_indexes.py
@@ -166,10 +166,10 @@ def test_create_fulltext_index_ensure_escaping(driver: MagicMock) -> None:
 
 def test_upsert_vector_happy_path(driver: MagicMock) -> None:
     id = 1
-    vector_prop = "embedding"
+    embedding_property = "embedding"
     vector = [1.0, 2.0, 3.0]
 
-    upsert_vector(driver, id, vector_prop, vector)
+    upsert_vector(driver, id, embedding_property, vector)
 
     upsert_query = """
         MATCH (n)
@@ -181,7 +181,7 @@ def test_upsert_vector_happy_path(driver: MagicMock) -> None:
 
     driver.execute_query.assert_called_once_with(
         upsert_query,
-        {"id": id, "vector_prop": vector_prop, "vector": vector},
+        {"id": id, "embedding_property": embedding_property, "vector": vector},
     )
 
 

--- a/tests/unit/test_indexes.py
+++ b/tests/unit/test_indexes.py
@@ -175,7 +175,7 @@ def test_upsert_vector_happy_path(driver: MagicMock) -> None:
         MATCH (n)
         WHERE elementId(n) = $id
         WITH n
-        CALL db.create.setNodeVectorProperty(n, $vector_prop, $vector)
+        CALL db.create.setNodeVectorProperty(n, $embedding_property, $vector)
         RETURN n
         """
 
@@ -189,11 +189,11 @@ def test_upsert_vector_raises_error_with_neo4j_insertion_error(
     driver: MagicMock,
 ) -> None:
     id = 1
-    vector_prop = "embedding"
+    embedding_property = "embedding"
     vector = [1.0, 2.0, 3.0]
     driver.execute_query.side_effect = neo4j.exceptions.ClientError
 
     with pytest.raises(Neo4jInsertionError) as excinfo:
-        upsert_vector(driver, id, vector_prop, vector)
+        upsert_vector(driver, id, embedding_property, vector)
 
     assert "Upserting vector to Neo4j failed" in str(excinfo)


### PR DESCRIPTION
# Description

This PR introduces breaking changes.

- Rename create_vector_index's `property` to `embedding_property` to make the variable more explicit, based on feedback.
- Rename `format_record_function` to `result_formatter` for clarity.
- Rename `default_format_record` to `default_record_formatter` for grammar consistency.
- Minor tweaks to documentation.


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [x] E2E tests have been updated
- [x] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
