### PR TITLE
Implemented exception chaining for all re-raised exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 -   Refactored import paths for retrievers to neo4j_genai.retrievers.
+-   Implemented exception chaining for all re-raised exceptions to improve stack trace readability.
+-   Made error messages in `index.py` more consistent.
 
 ## 0.2.0
 

--- a/src/neo4j_genai/embeddings/sentence_transformers.py
+++ b/src/neo4j_genai/embeddings/sentence_transformers.py
@@ -10,11 +10,11 @@ class SentenceTransformerEmbeddings(Embedder):
     ) -> None:
         try:
             from sentence_transformers import SentenceTransformer
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 "Could not import sentence_transformers python package. "
                 "Please install it with `pip install sentence-transformers`."
-            )
+            ) from e
 
         self.model = SentenceTransformer(model, *args, **kwargs)
 

--- a/src/neo4j_genai/indexes.py
+++ b/src/neo4j_genai/indexes.py
@@ -65,7 +65,9 @@ def create_vector_index(
             similarity_fn=similarity_fn,
         )
     except ValidationError as e:
-        raise Neo4jIndexError(f"Error for inputs to create_vector_index {str(e)}")
+        raise Neo4jIndexError(
+            f"Error for inputs to create_vector_index {str(e)}"
+        ) from e
 
     try:
         query = (
@@ -78,7 +80,7 @@ def create_vector_index(
             {"name": name, "dimensions": dimensions, "similarity_fn": similarity_fn},
         )
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Neo4j vector index creation failed: {e}")
+        raise Neo4jIndexError(f"Neo4j vector index creation failed: {e}") from e
 
 
 def create_fulltext_index(
@@ -108,7 +110,9 @@ def create_fulltext_index(
             driver=driver, name=name, label=label, node_properties=node_properties
         )
     except ValidationError as e:
-        raise Neo4jIndexError(f"Error for inputs to create_fulltext_index: {str(e)}")
+        raise Neo4jIndexError(
+            f"Error for inputs to create_fulltext_index: {str(e)}"
+        ) from e
 
     try:
         query = (
@@ -119,7 +123,7 @@ def create_fulltext_index(
         logger.info(f"Creating fulltext index named '{name}'")
         driver.execute_query(query, {"name": name})
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Neo4j fulltext index creation failed {e}")
+        raise Neo4jIndexError(f"Neo4j fulltext index creation failed {e}") from e
 
 
 def drop_index_if_exists(driver: neo4j.Driver, name: str) -> None:
@@ -143,7 +147,7 @@ def drop_index_if_exists(driver: neo4j.Driver, name: str) -> None:
         logger.info(f"Dropping index named '{name}'")
         driver.execute_query(query, parameters)
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Dropping Neo4j index failed: {e}")
+        raise Neo4jIndexError(f"Dropping Neo4j index failed: {e}") from e
 
 
 def upsert_vector(
@@ -179,4 +183,4 @@ def upsert_vector(
         }
         driver.execute_query(query, parameters)
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jInsertionError(f"Upserting vector to Neo4j failed: {e}")
+        raise Neo4jInsertionError(f"Upserting vector to Neo4j failed: {e}") from e

--- a/src/neo4j_genai/indexes.py
+++ b/src/neo4j_genai/indexes.py
@@ -66,7 +66,7 @@ def create_vector_index(
         )
     except ValidationError as e:
         raise Neo4jIndexError(
-            f"Error for inputs to create_vector_index {str(e)}"
+            f"Error for inputs to create_vector_index {e.errors()}"
         ) from e
 
     try:
@@ -80,7 +80,7 @@ def create_vector_index(
             {"name": name, "dimensions": dimensions, "similarity_fn": similarity_fn},
         )
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Neo4j vector index creation failed: {e}") from e
+        raise Neo4jIndexError(f"Neo4j vector index creation failed: {e.message}") from e
 
 
 def create_fulltext_index(
@@ -111,7 +111,7 @@ def create_fulltext_index(
         )
     except ValidationError as e:
         raise Neo4jIndexError(
-            f"Error for inputs to create_fulltext_index: {str(e)}"
+            f"Error for inputs to create_fulltext_index: {e.errors()}"
         ) from e
 
     try:
@@ -123,7 +123,9 @@ def create_fulltext_index(
         logger.info(f"Creating fulltext index named '{name}'")
         driver.execute_query(query, {"name": name})
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Neo4j fulltext index creation failed {e}") from e
+        raise Neo4jIndexError(
+            f"Neo4j fulltext index creation failed {e.message}"
+        ) from e
 
 
 def drop_index_if_exists(driver: neo4j.Driver, name: str) -> None:
@@ -147,7 +149,7 @@ def drop_index_if_exists(driver: neo4j.Driver, name: str) -> None:
         logger.info(f"Dropping index named '{name}'")
         driver.execute_query(query, parameters)
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jIndexError(f"Dropping Neo4j index failed: {e}") from e
+        raise Neo4jIndexError(f"Dropping Neo4j index failed: {e.message}") from e
 
 
 def upsert_vector(
@@ -183,4 +185,6 @@ def upsert_vector(
         }
         driver.execute_query(query, parameters)
     except neo4j.exceptions.ClientError as e:
-        raise Neo4jInsertionError(f"Upserting vector to Neo4j failed: {e}") from e
+        raise Neo4jInsertionError(
+            f"Upserting vector to Neo4j failed: {e.message}"
+        ) from e

--- a/src/neo4j_genai/retrievers/base.py
+++ b/src/neo4j_genai/retrievers/base.py
@@ -73,8 +73,8 @@ class Retriever(ABC):
             self._node_label = result["labels"][0]
             self._embedding_node_property = result["properties"][0]
             self._embedding_dimension = result["dimensions"]
-        except IndexError:
-            raise Exception(f"No index with name {self.index_name} found")
+        except IndexError as e:
+            raise Exception(f"No index with name {self.index_name} found") from e
 
     def search(self, *args: Any, **kwargs: Any) -> RetrieverResult:
         """

--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -109,7 +109,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
                 format_record_function=format_record_function,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(
             driver=driver,
@@ -190,7 +190,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
                 pinecone_filter=pinecone_filters,
             )
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         if validated_data.query_text:
             if self.embedder:

--- a/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
@@ -102,7 +102,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
                 format_record_function=format_record_function,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(driver, id_property_external, id_property_neo4j)
         self.client = validated_data.client_model.client
@@ -176,7 +176,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
             top_k = validated_data.top_k
             weaviate_filters = validated_data.weaviate_filters
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         # If we want to use a local embedder, we still want to call the near_vector method
         # so we want to create the vector as early as possible here

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -88,7 +88,7 @@ class HybridRetriever(Retriever):
                 return_properties=return_properties,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(validated_data.driver_model.driver)
         self.vector_index_name = validated_data.vector_index_name
@@ -152,7 +152,7 @@ class HybridRetriever(Retriever):
                 query_text=query_text,
             )
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
 
@@ -229,7 +229,7 @@ class HybridCypherRetriever(Retriever):
                 embedder_model=embedder_model,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(validated_data.driver_model.driver)
         self.vector_index_name = validated_data.vector_index_name
@@ -283,7 +283,7 @@ class HybridCypherRetriever(Retriever):
                 query_params=query_params,
             )
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
 

--- a/src/neo4j_genai/retrievers/text2cypher.py
+++ b/src/neo4j_genai/retrievers/text2cypher.py
@@ -77,7 +77,7 @@ class Text2CypherRetriever(Retriever):
                 examples=examples,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(validated_data.driver_model.driver)
         self.llm = validated_data.llm_model.llm
@@ -92,7 +92,7 @@ class Text2CypherRetriever(Retriever):
             error_message = getattr(e, "message", str(e))
             raise SchemaFetchError(
                 f"Failed to fetch schema for Text2CypherRetriever: {error_message}"
-            )
+            ) from e
 
     def _get_search_results(
         self,
@@ -114,7 +114,7 @@ class Text2CypherRetriever(Retriever):
         try:
             validated_data = Text2CypherSearchModel(query_text=query_text)
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         prompt_template = Text2CypherTemplate()
         prompt = prompt_template.format(
@@ -130,7 +130,9 @@ class Text2CypherRetriever(Retriever):
             logger.debug("Text2CypherRetriever Cypher query: %s", t2c_query)
             records, _, _ = self.driver.execute_query(query_=t2c_query)
         except CypherSyntaxError as e:
-            raise Text2CypherRetrievalError(f"Failed to get search result: {e.message}")
+            raise Text2CypherRetrievalError(
+                f"Failed to get search result: {e.message}"
+            ) from e
 
         return RawSearchResult(
             records=records,

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -86,7 +86,7 @@ class VectorRetriever(Retriever):
                 return_properties=return_properties,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(driver)
         self.index_name = validated_data.index_name
@@ -151,7 +151,7 @@ class VectorRetriever(Retriever):
                 query_text=query_text,
             )
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
 
@@ -228,7 +228,7 @@ class VectorCypherRetriever(Retriever):
                 embedder_model=embedder_model,
             )
         except ValidationError as e:
-            raise RetrieverInitializationError(e.errors())
+            raise RetrieverInitializationError(e.errors()) from e
 
         super().__init__(driver)
         self.index_name = validated_data.index_name
@@ -281,7 +281,7 @@ class VectorCypherRetriever(Retriever):
                 query_params=query_params,
             )
         except ValidationError as e:
-            raise SearchValidationError(e.errors())
+            raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
 


### PR DESCRIPTION
# Description

This is a small PR which adds the `from` keyword to all re-raised exceptions. The effect of this is to make the resulting stack traces more readable i.e. traces such as this
```bash
⋮
raise Neo4jError.hydrate(**metadata)
neo4j.exceptions.ClientError: {code: Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists} {message: An equivalent index already exists, 'Index( id=1, name='movie_tagline_embeddings', type='VECTOR', schema=(:Movie {taglineEmbedding}), indexProvider='vector-2.0' )'.}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alexthomas/Documents/neo4j-genai-python/a.py", line 20, in <module>
    create_vector_index(
  File "/Users/alexthomas/Documents/neo4j-genai-python/src/neo4j_genai/indexes.py", line 83, in create_vector_index
    raise Neo4jIndexError("Neo4j vector index creation failed.")
neo4j_genai.exceptions.Neo4jIndexError: Neo4j vector index creation failed.
```
are replaced by traces such as this
```bash
⋮
raise Neo4jError.hydrate(**metadata)
neo4j.exceptions.ClientError: {code: Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists} {message: An equivalent index already exists, 'Index( id=1, name='movie_tagline_embeddings', type='VECTOR', schema=(:Movie {taglineEmbedding}), indexProvider='vector-2.0' )'.}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/alexthomas/Documents/neo4j-genai-python/a.py", line 20, in <module>
    create_vector_index(
  File "/Users/alexthomas/Documents/neo4j-genai-python/src/neo4j_genai/indexes.py", line 83, in create_vector_index
    raise Neo4jIndexError("Neo4j vector index creation failed.") from e
neo4j_genai.exceptions.Neo4jIndexError: Neo4j vector index creation failed.
```

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
