### PR TITLE
Pydantic search model refactoring

### DIFF
--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -179,14 +179,14 @@ class PineconeNeo4jRetriever(ExternalRetriever):
             RawSearchResult: The results of the search query as a list of neo4j.Record and an optional metadata dict
         """
 
-        pinecone_filters = kwargs.get("pinecone_filters")
+        pinecone_filter = kwargs.get("pinecone_filter")
 
         try:
             validated_data = PineconeSearchModel(
                 query_vector=query_vector,
                 query_text=query_text,
                 top_k=top_k,
-                pinecone_filter=pinecone_filters,
+                pinecone_filter=pinecone_filter,
             )
         except ValidationError as e:
             raise SearchValidationError(e.errors()) from e

--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -183,7 +183,6 @@ class PineconeNeo4jRetriever(ExternalRetriever):
 
         try:
             validated_data = PineconeSearchModel(
-                vector_index_name=self.index_name,
                 query_vector=query_vector,
                 query_text=query_text,
                 top_k=top_k,

--- a/src/neo4j_genai/retrievers/external/pinecone/types.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/types.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import neo4j
 from pinecone import Pinecone
@@ -29,7 +29,7 @@ from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
 
 class PineconeSearchModel(VectorSearchModel):
     pinecone_filter: Optional[
-        Dict[str, Union[str, float, int, bool, List[Any], Dict[Any, Any]]]
+        dict[str, Union[str, float, int, bool, list[Any], dict[Any, Any]]]
     ] = None
 
 

--- a/src/neo4j_genai/retrievers/external/pinecone/types.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/types.py
@@ -13,7 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from __future__ import annotations
-from typing import Any, Callable, Optional
+
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import neo4j
 from pinecone import Pinecone
@@ -27,7 +28,9 @@ from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
 
 
 class PineconeSearchModel(VectorSearchModel):
-    pinecone_filter: Optional[dict[str, Any]] = None
+    pinecone_filter: Optional[
+        Dict[str, Union[str, float, int, bool, List[Any], Dict[Any, Any]]]
+    ] = None
 
 
 class PineconeClientModel(BaseModel):

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -14,20 +14,18 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import neo4j
 from pydantic import (
     BaseModel,
     ConfigDict,
     field_validator,
-    model_validator,
 )
 from weaviate.client import WeaviateClient
 from weaviate.collections.classes.filters import _Filters
 
 from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
-from neo4j_genai.utils import validate_search_query_input
 
 
 class WeaviateModel(BaseModel):

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -13,21 +13,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from __future__ import annotations
-from typing import Optional, Any, Callable
+
+from typing import Any, Callable, Optional
 
 import neo4j
 from pydantic import (
-    field_validator,
     BaseModel,
-    PositiveInt,
-    model_validator,
     ConfigDict,
+    field_validator,
+    model_validator,
 )
 from weaviate.client import WeaviateClient
 from weaviate.collections.classes.filters import _Filters
 
+from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
 from neo4j_genai.utils import validate_search_query_input
-from neo4j_genai.types import Neo4jDriverModel, EmbedderModel
 
 
 class WeaviateModel(BaseModel):
@@ -55,10 +55,7 @@ class WeaviateNeo4jRetrieverModel(BaseModel):
     result_formatter: Optional[Callable[[neo4j.Record], str]] = None
 
 
-class WeaviateNeo4jSearchModel(BaseModel):
-    top_k: PositiveInt = 5
-    query_vector: Optional[list[float]] = None
-    query_text: Optional[str] = None
+class WeaviateNeo4jSearchModel(VectorSearchModel):
     weaviate_filters: Optional[_Filters] = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -66,12 +66,3 @@ class WeaviateNeo4jSearchModel(VectorSearchModel):
                 "Provided filters need to be of type weaviate.collections.classes.filters._Filters"
             )
         return value
-
-    @model_validator(mode="before")
-    def check_query(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """
-        Validates that one of either query_vector or query_text is provided exclusively.
-        """
-        query_vector, query_text = values.get("query_vector"), values.get("query_text")
-        validate_search_query_input(query_text, query_vector)
-        return values

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -31,6 +31,7 @@ from neo4j_genai.retrievers.base import Retriever
 from neo4j_genai.types import (
     EmbedderModel,
     HybridCypherRetrieverModel,
+    HybridCypherSearchModel,
     HybridRetrieverModel,
     HybridSearchModel,
     Neo4jDriverModel,
@@ -275,7 +276,7 @@ class HybridCypherRetriever(Retriever):
             RawSearchResult: The results of the search query as a list of neo4j.Record and an optional metadata dict
         """
         try:
-            validated_data = HybridSearchModel(
+            validated_data = HybridCypherSearchModel(
                 query_vector=query_vector,
                 query_text=query_text,
                 top_k=top_k,

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -156,6 +156,8 @@ class VectorRetriever(Retriever):
 
         parameters = validated_data.model_dump(exclude_none=True)
         parameters["vector_index_name"] = self.index_name
+        if filters:
+            del parameters["filters"]
 
         if query_text:
             if not self.embedder:
@@ -287,6 +289,8 @@ class VectorCypherRetriever(Retriever):
 
         parameters = validated_data.model_dump(exclude_none=True)
         parameters["vector_index_name"] = self.index_name
+        if filters:
+            del parameters["filters"]
 
         if query_text:
             if not self.embedder:

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -13,32 +13,31 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 from __future__ import annotations
-from typing import Optional, Any, Callable
+
+import logging
+from typing import Any, Callable, Optional
 
 import neo4j
-
-from neo4j_genai.exceptions import (
-    RetrieverInitializationError,
-    SearchValidationError,
-    EmbeddingRequiredError,
-)
-from neo4j_genai.retrievers.base import Retriever
 from pydantic import ValidationError
 
 from neo4j_genai.embedder import Embedder
-from neo4j_genai.types import (
-    VectorSearchModel,
-    VectorCypherSearchModel,
-    SearchType,
-    Neo4jDriverModel,
-    EmbedderModel,
-    VectorRetrieverModel,
-    VectorCypherRetrieverModel,
-    RawSearchResult,
-    RetrieverResultItem,
+from neo4j_genai.exceptions import (
+    EmbeddingRequiredError,
+    RetrieverInitializationError,
+    SearchValidationError,
 )
 from neo4j_genai.neo4j_queries import get_search_query
-import logging
+from neo4j_genai.retrievers.base import Retriever
+from neo4j_genai.types import (
+    EmbedderModel,
+    Neo4jDriverModel,
+    RawSearchResult,
+    RetrieverResultItem,
+    SearchType,
+    VectorCypherRetrieverModel,
+    VectorRetrieverModel,
+    VectorSearchModel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -146,15 +145,16 @@ class VectorRetriever(Retriever):
         """
         try:
             validated_data = VectorSearchModel(
-                vector_index_name=self.index_name,
-                top_k=top_k,
                 query_vector=query_vector,
                 query_text=query_text,
+                top_k=top_k,
+                filters=filters,
             )
         except ValidationError as e:
             raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
+        parameters["vector_index_name"] = self.index_name
 
         if query_text:
             if not self.embedder:
@@ -274,17 +274,18 @@ class VectorCypherRetriever(Retriever):
             RawSearchResult: The results of the search query as a list of neo4j.Record and an optional metadata dict
         """
         try:
-            validated_data = VectorCypherSearchModel(
-                vector_index_name=self.index_name,
-                top_k=top_k,
+            validated_data = VectorSearchModel(
                 query_vector=query_vector,
                 query_text=query_text,
+                top_k=top_k,
                 query_params=query_params,
+                filters=filters,
             )
         except ValidationError as e:
             raise SearchValidationError(e.errors()) from e
 
         parameters = validated_data.model_dump(exclude_none=True)
+        parameters["vector_index_name"] = self.index_name
 
         if query_text:
             if not self.embedder:

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -35,6 +35,7 @@ from neo4j_genai.types import (
     RetrieverResultItem,
     SearchType,
     VectorCypherRetrieverModel,
+    VectorCypherSearchModel,
     VectorRetrieverModel,
     VectorSearchModel,
 )
@@ -274,7 +275,7 @@ class VectorCypherRetriever(Retriever):
             RawSearchResult: The results of the search query as a list of neo4j.Record and an optional metadata dict
         """
         try:
-            validated_data = VectorSearchModel(
+            validated_data = VectorCypherSearchModel(
                 query_vector=query_vector,
                 query_text=query_text,
                 top_k=top_k,

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -116,10 +116,11 @@ class FulltextIndexModel(IndexModel):
 
 
 class VectorSearchModel(BaseModel):
-    vector_index_name: str
-    top_k: PositiveInt = 5
     query_vector: Optional[list[float]] = None
     query_text: Optional[str] = None
+    top_k: PositiveInt = 5
+    query_params: Optional[dict[str, Any]] = None
+    filters: Optional[dict[str, Any]] = None
 
     @model_validator(mode="before")
     def check_query(cls, values: dict[str, Any]) -> dict[str, Any]:
@@ -131,19 +132,10 @@ class VectorSearchModel(BaseModel):
         return values
 
 
-class VectorCypherSearchModel(VectorSearchModel):
-    query_params: Optional[dict[str, Any]] = None
-
-
 class HybridSearchModel(BaseModel):
-    vector_index_name: str
-    fulltext_index_name: str
     query_text: str
-    top_k: PositiveInt = 5
     query_vector: Optional[list[float]] = None
-
-
-class HybridCypherSearchModel(HybridSearchModel):
+    top_k: PositiveInt = 5
     query_params: Optional[dict[str, Any]] = None
 
 

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -119,7 +119,6 @@ class VectorSearchModel(BaseModel):
     query_vector: Optional[list[float]] = None
     query_text: Optional[str] = None
     top_k: PositiveInt = 5
-    query_params: Optional[dict[str, Any]] = None
     filters: Optional[dict[str, Any]] = None
 
     @model_validator(mode="before")
@@ -132,10 +131,17 @@ class VectorSearchModel(BaseModel):
         return values
 
 
+class VectorCypherSearchModel(VectorSearchModel):
+    query_params: Optional[dict[str, Any]] = None
+
+
 class HybridSearchModel(BaseModel):
     query_text: str
     query_vector: Optional[list[float]] = None
     top_k: PositiveInt = 5
+
+
+class HybridCypherSearchModel(HybridSearchModel):
     query_params: Optional[dict[str, Any]] = None
 
 


### PR DESCRIPTION
# Description

This simplifies the Pydantic models used to validate the `search` methods of retrievers by removing fields that are already validated by the retrievers' `__init__` methods.

**NOTE** This PR does not merge the search models. Given the vector search models allow for only one input (either a `query_vector` or `query_text`) and the hybrid search models allow for both inputs it is not possible to merge them.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
