### PR TITLE
Structured retriever results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 -   Improved developer experience by copying the docstring from the `Retriever.get_search_results` method to the `Retriever.search` method
 -   Support for specifying database names in index handling methods and retrievers.
 -   User Guide in documentation.
+-   Introduced result_formatter argument to all retrievers, allowing custom formatting of retriever results.
 
 ### Changed
 -   Refactored import paths for retrievers to neo4j_genai.retrievers.

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -430,7 +430,7 @@ Format the Results
 
 .. warning::
 
-    This API is in beta mode and will be subject to change is the future.
+    This API is in beta mode and will be subject to change in the future.
 
 For improved readability and ease in prompt-engineering, formatting the result to suit
 specific needs involves providing a `record_formatter` function to the Cypher retrievers.

--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -95,7 +95,9 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
         retrieval_query: Optional[str] = None,
-        result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ):
         try:

--- a/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/pinecone.py
@@ -38,6 +38,7 @@ from neo4j_genai.types import (
     EmbedderModel,
     Neo4jDriverModel,
     RawSearchResult,
+    RetrieverResultItem,
 )
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         id_property_neo4j (str): The name of the Neo4j node property that's used as the identifier for relating matches from Weaviate to Neo4j nodes.
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
-        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Function to transform a neo4j.Record to a RetrieverResultItem.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     Raises:
@@ -94,7 +95,7 @@ class PineconeNeo4jRetriever(ExternalRetriever):
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
         retrieval_query: Optional[str] = None,
-        result_formatter: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None,
         neo4j_database: Optional[str] = None,
     ):
         try:

--- a/src/neo4j_genai/retrievers/external/pinecone/types.py
+++ b/src/neo4j_genai/retrievers/external/pinecone/types.py
@@ -24,7 +24,12 @@ from pydantic import (
     field_validator,
 )
 
-from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
+from neo4j_genai.types import (
+    EmbedderModel,
+    Neo4jDriverModel,
+    RetrieverResultItem,
+    VectorSearchModel,
+)
 
 
 class PineconeSearchModel(VectorSearchModel):
@@ -52,5 +57,5 @@ class PineconeNeo4jRetrieverModel(BaseModel):
     embedder_model: Optional[EmbedderModel] = None
     return_properties: Optional[list[str]] = None
     retrieval_query: Optional[str] = None
-    result_formatter: Optional[Callable[[neo4j.Record], str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -50,7 +50,7 @@ class WeaviateNeo4jRetrieverModel(BaseModel):
     embedder_model: Optional[EmbedderModel]
     return_properties: Optional[list[str]] = None
     retrieval_query: Optional[str] = None
-    result_formatter: Optional[Callable[[neo4j.Record], str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
 
 

--- a/src/neo4j_genai/retrievers/external/weaviate/types.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/types.py
@@ -25,7 +25,12 @@ from pydantic import (
 from weaviate.client import WeaviateClient
 from weaviate.collections.classes.filters import _Filters
 
-from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, VectorSearchModel
+from neo4j_genai.types import (
+    EmbedderModel,
+    Neo4jDriverModel,
+    RetrieverResultItem,
+    VectorSearchModel,
+)
 
 
 class WeaviateModel(BaseModel):

--- a/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
@@ -31,7 +31,12 @@ from neo4j_genai.retrievers.external.weaviate.types import (
     WeaviateNeo4jRetrieverModel,
     WeaviateNeo4jSearchModel,
 )
-from neo4j_genai.types import EmbedderModel, Neo4jDriverModel, RawSearchResult
+from neo4j_genai.types import (
+    EmbedderModel,
+    Neo4jDriverModel,
+    RawSearchResult,
+    RetrieverResultItem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +91,9 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
         retrieval_query: Optional[str] = None,
-        result_formatter: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ):
         try:

--- a/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
+++ b/src/neo4j_genai/retrievers/external/weaviate/weaviate.py
@@ -69,7 +69,7 @@ class WeaviateNeo4jRetriever(ExternalRetriever):
         id_property_neo4j (str): The name of the Neo4j node property that's used as the identifier for relating matches from Weaviate to Neo4j nodes.
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
-        result_formatter (Optional[Callable[[Any], Any]]): Function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Function to transform a neo4j.Record to a RetrieverResultItem.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     Raises:

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -70,7 +70,7 @@ class HybridRetriever(Retriever):
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
-
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
     """
 
     def __init__(
@@ -80,6 +80,9 @@ class HybridRetriever(Retriever):
         fulltext_index_name: str,
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ) -> None:
         try:
@@ -91,6 +94,7 @@ class HybridRetriever(Retriever):
                 fulltext_index_name=fulltext_index_name,
                 embedder_model=embedder_model,
                 return_properties=return_properties,
+                result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
             )
         except ValidationError as e:
@@ -107,6 +111,7 @@ class HybridRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
+        self.result_formatter = validated_data.result_formatter
 
     def default_record_formatter(self, record: neo4j.Record) -> RetrieverResultItem:
         """
@@ -219,7 +224,7 @@ class HybridCypherRetriever(Retriever):
         fulltext_index_name (str): Fulltext index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        result_formatter (Optional[Callable[[Any], Any]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     Raises:
@@ -233,7 +238,9 @@ class HybridCypherRetriever(Retriever):
         fulltext_index_name: str,
         retrieval_query: str,
         embedder: Optional[Embedder] = None,
-        result_formatter: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ) -> None:
         try:
@@ -245,7 +252,6 @@ class HybridCypherRetriever(Retriever):
                 fulltext_index_name=fulltext_index_name,
                 retrieval_query=retrieval_query,
                 embedder_model=embedder_model,
-                neo4j_database=neo4j_database,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors()) from e
@@ -261,7 +267,7 @@ class HybridCypherRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
-        self.result_formatter = result_formatter
+        self.result_formatter = validated_data.result_formatter
 
     def get_search_results(
         self,

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -71,6 +71,11 @@ class HybridRetriever(Retriever):
         return_properties (Optional[list[str]]): List of node properties to return.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
         result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
+
+            Two variables are provided in the neo4j.Record:
+
+            -   node: Represents the node retrieved from the vector index search.
+            -   score: Denotes the similarity score.
     """
 
     def __init__(

--- a/src/neo4j_genai/retrievers/hybrid.py
+++ b/src/neo4j_genai/retrievers/hybrid.py
@@ -252,6 +252,8 @@ class HybridCypherRetriever(Retriever):
                 fulltext_index_name=fulltext_index_name,
                 retrieval_query=retrieval_query,
                 embedder_model=embedder_model,
+                result_formatter=result_formatter,
+                neo4j_database=neo4j_database,
             )
         except ValidationError as e:
             raise RetrieverInitializationError(e.errors()) from e

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -65,6 +65,7 @@ class VectorRetriever(Retriever):
         index_name (str): Vector index name.
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     Raises:
@@ -77,6 +78,9 @@ class VectorRetriever(Retriever):
         index_name: str,
         embedder: Optional[Embedder] = None,
         return_properties: Optional[list[str]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ) -> None:
         try:
@@ -87,6 +91,7 @@ class VectorRetriever(Retriever):
                 index_name=index_name,
                 embedder_model=embedder_model,
                 return_properties=return_properties,
+                result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
             )
         except ValidationError as e:
@@ -102,6 +107,7 @@ class VectorRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
+        self.result_formatter = validated_data.result_formatter
         self._node_label = None
         self._embedding_node_property = None
         self._embedding_dimension = None
@@ -222,7 +228,7 @@ class VectorCypherRetriever(Retriever):
         index_name (str): Vector index name.
         retrieval_query (str): Cypher query that gets appended.
         embedder (Optional[Embedder]): Embedder object to embed query text.
-        result_formatter (Optional[Callable[[Any], Any]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
+        result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     """
@@ -233,7 +239,9 @@ class VectorCypherRetriever(Retriever):
         index_name: str,
         retrieval_query: str,
         embedder: Optional[Embedder] = None,
-        result_formatter: Optional[Callable[[Any], Any]] = None,
+        result_formatter: Optional[
+            Callable[[neo4j.Record], RetrieverResultItem]
+        ] = None,
         neo4j_database: Optional[str] = None,
     ) -> None:
         try:
@@ -244,6 +252,7 @@ class VectorCypherRetriever(Retriever):
                 index_name=index_name,
                 retrieval_query=retrieval_query,
                 embedder_model=embedder_model,
+                result_formatter=result_formatter,
                 neo4j_database=neo4j_database,
             )
         except ValidationError as e:
@@ -259,7 +268,7 @@ class VectorCypherRetriever(Retriever):
             if validated_data.embedder_model
             else None
         )
-        self.result_formatter = result_formatter
+        self.result_formatter = validated_data.result_formatter
         self._node_label = None
         self._node_embedding_property = None
         self._embedding_dimension = None

--- a/src/neo4j_genai/retrievers/vector.py
+++ b/src/neo4j_genai/retrievers/vector.py
@@ -66,6 +66,12 @@ class VectorRetriever(Retriever):
         embedder (Optional[Embedder]): Embedder object to embed query text.
         return_properties (Optional[list[str]]): List of node properties to return.
         result_formatter (Optional[Callable[[neo4j.Record], RetrieverResultItem]]): Provided custom function to transform a neo4j.Record to a RetrieverResultItem.
+
+            Two variables are provided in the neo4j.Record:
+
+            -   node: Represents the node retrieved from the vector index search.
+            -   score: Denotes the similarity score.
+
         neo4j_database (Optional[str]): The name of the Neo4j database. If not provided, this defaults to "neo4j" in the database (`see reference to documentation <https://neo4j.com/docs/operations-manual/current/database-administration/#manage-databases-default>`_).
 
     Raises:

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Any, Callable, Literal, Optional
 
 import neo4j
 from pydantic import (
@@ -201,6 +201,7 @@ class VectorRetrieverModel(BaseModel):
     index_name: str
     embedder_model: Optional[EmbedderModel] = None
     return_properties: Optional[list[str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
 
 
@@ -209,6 +210,7 @@ class VectorCypherRetrieverModel(BaseModel):
     index_name: str
     retrieval_query: str
     embedder_model: Optional[EmbedderModel] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
 
 
@@ -218,6 +220,7 @@ class HybridRetrieverModel(BaseModel):
     fulltext_index_name: str
     embedder_model: Optional[EmbedderModel] = None
     return_properties: Optional[list[str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
 
 
@@ -227,6 +230,7 @@ class HybridCypherRetrieverModel(BaseModel):
     fulltext_index_name: str
     retrieval_query: str
     embedder_model: Optional[EmbedderModel] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
     neo4j_database: Optional[str] = None
 
 
@@ -235,3 +239,4 @@ class Text2CypherRetrieverModel(BaseModel):
     llm_model: LLMModel
     neo4j_schema_model: Optional[Neo4jSchemaModel] = None
     examples: Optional[list[str]] = None
+    result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import neo4j
@@ -25,6 +26,7 @@ from neo4j_genai.retrievers import (
     VectorCypherRetriever,
     VectorRetriever,
 )
+from neo4j_genai.types import RetrieverResultItem
 
 
 @pytest.fixture(scope="function")
@@ -84,4 +86,15 @@ def t2c_retriever(
 
 @pytest.fixture(scope="function")
 def neo4j_record() -> neo4j.Record:
-    return neo4j.Record({"node": "dummy-node", "score": 1.0})
+    return neo4j.Record({"node": "dummy-node", "score": 1.0, "node_id": 123})
+
+
+@pytest.fixture(scope="function")
+def result_formatter() -> Callable[[neo4j.Record], RetrieverResultItem]:
+    def format_function(record: neo4j.Record) -> RetrieverResultItem:
+        return RetrieverResultItem(
+            content=record.get("node"),
+            metadata={"score": record.get("score"), "node_id": record.get("node_id")},
+        )
+
+    return format_function

--- a/tests/unit/retrievers/external/test_pinecone.py
+++ b/tests/unit/retrievers/external/test_pinecone.py
@@ -245,3 +245,35 @@ def test_pinecone_retriever_search_retrieval_query(
         ],
         metadata={"__retriever": "PineconeNeo4jRetriever"},
     )
+
+
+def test_pinecone_retriever_with_result_format_function(
+    driver: MagicMock,
+    client: MagicMock,
+    neo4j_record: MagicMock,
+    result_formatter: MagicMock,
+) -> None:
+    retriever = PineconeNeo4jRetriever(
+        driver=driver,
+        client=client,
+        index_name="dummy-text",
+        id_property_neo4j="sync_id",
+        result_formatter=result_formatter,
+    )
+    with mock.patch.object(retriever, "index"):
+        driver.execute_query.return_value = (
+            [neo4j_record],
+            None,
+            None,
+        )
+        query_vector = [1.0 for _ in range(1536)]
+        records = retriever.search(query_vector=query_vector)
+
+    assert records == RetrieverResult(
+        items=[
+            RetrieverResultItem(
+                content="dummy-node", metadata={"score": 1.0, "node_id": 123}
+            ),
+        ],
+        metadata={"__retriever": "PineconeNeo4jRetriever"},
+    )

--- a/tests/unit/retrievers/test_hybrid.py
+++ b/tests/unit/retrievers/test_hybrid.py
@@ -237,6 +237,7 @@ def test_hybrid_search_favors_query_vector_over_embedding_vector(
             "fulltext_index_name": fulltext_index_name,
             "query_vector": query_vector,
         },
+        database_=database,
     )
     embedder.embed_query.assert_not_called()
 

--- a/tests/unit/retrievers/test_vector.py
+++ b/tests/unit/retrievers/test_vector.py
@@ -14,7 +14,6 @@
 #  limitations under the License.
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import neo4j


### PR DESCRIPTION
# Description

This PR adds the `result_formatter` argument to the `__init__` of all retrievers that didn't already have it. This allows developers to format the records returned from a retriever using a function. Additional unit tests have been added to test this functionality for each retriever.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Medium

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [X] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
