### PR TITLE
fix typo in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ upsert_query(
 
 Assumption: Neo4j running with populated vector index in place.
 
-Limitation: The query over the vector index is an _approximate_ nearest neighbor search and may not give exact results. [See this reference for more details](https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#_limitiations_and_known_issues).
+Limitation: The query over the vector index is an _approximate_ nearest neighbor search and may not give exact results. [See this reference for more details](https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#limitations-and-issues).
 
 While the library has more retrievers than shown here, the following examples should be able to get you started.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -174,7 +174,7 @@ While the library has more retrievers than shown here, the following examples sh
 Limitations
 ***********
 
-The query over the vector index is an *approximate* nearest neighbor search and may not give exact results. `See this reference for more details <https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#_limitiations_and_known_issues>`_.
+The query over the vector index is an *approximate* nearest neighbor search and may not give exact results. `See this reference for more details <https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#limitations-and-issues>`_.
 
 
 Development

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -220,7 +220,7 @@ The `index_name` is the name of the Neo4j vector index that will be used for sim
 .. warning::
 
     Vector index use an **approximate nearest neighbor** algorithm.
-    Refer to the `Neo4j Documentation <https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#_limitiations_and_known_issues>`_ to learn about its limitations.
+    Refer to the `Neo4j Documentation <https://neo4j.com/docs/cypher-manual/current/indexes/semantic-indexes/vector-indexes/#limitations-and-issues>`_ to learn about its limitations.
 
 
 Search Similar Vector


### PR DESCRIPTION
Typo in Cypher Manual header. PR [here](https://github.com/neo4j/docs-cypher/pull/999).
This PR will fix links in genai python docs accordingly.
