### PR TITLE
Fix import and init issue with using OpenAIEmbeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+### Fixed
+-   Corrected initialization to allow specifying the embedding model name.
+-   Removed sentence_transformers from embeddings/__init__.py to avoid ImportError when the package is not installed.
+
 ## 0.3.0
 
 ### Added

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -266,7 +266,7 @@ The `OpenAIEmbedder` was illustrated previously. Here is how to use the `Sentenc
 
 .. code:: python
 
-    from neo4j_genai.embeddings import SentenceTransformerEmbeddings
+    from neo4j_genai.embeddings.sentence_transformers import SentenceTransformerEmbeddings
 
     embedder = SentenceTransformerEmbeddings(model="all-MiniLM-L6-v2")  # Note: this is the default model
 

--- a/examples/graphrag.py
+++ b/examples/graphrag.py
@@ -19,7 +19,7 @@ from neo4j_genai.types import RetrieverResultItem
 URI = "neo4j://localhost:7687"
 AUTH = ("neo4j", "password")
 DATABASE = "neo4j"
-INDEX = "moviePlotsEmbedding"
+INDEX = "vector-index-name"
 
 
 # setup logger config

--- a/examples/graphrag.py
+++ b/examples/graphrag.py
@@ -19,7 +19,7 @@ from neo4j_genai.types import RetrieverResultItem
 URI = "neo4j://localhost:7687"
 AUTH = ("neo4j", "password")
 DATABASE = "neo4j"
-INDEX = "vector-index-name"
+INDEX = "moviePlotsEmbedding"
 
 
 # setup logger config

--- a/src/neo4j_genai/embeddings/__init__.py
+++ b/src/neo4j_genai/embeddings/__init__.py
@@ -1,5 +1,14 @@
-from .sentence_transformers import SentenceTransformerEmbeddings
-
-__all__ = [
-    "SentenceTransformerEmbeddings",
-]
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/neo4j_genai/embeddings/openai.py
+++ b/src/neo4j_genai/embeddings/openai.py
@@ -1,3 +1,18 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from __future__ import annotations
 
 from typing import Any

--- a/src/neo4j_genai/embeddings/openai.py
+++ b/src/neo4j_genai/embeddings/openai.py
@@ -6,7 +6,7 @@ from neo4j_genai.embedder import Embedder
 
 
 class OpenAIEmbeddings(Embedder):
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, model: str = "text-embedding-ada-002") -> None:
         try:
             import openai
         except ImportError:
@@ -15,10 +15,11 @@ class OpenAIEmbeddings(Embedder):
                 "Please install it with `pip install openai`."
             )
 
-        self.model = openai.OpenAI(*args, **kwargs)
+        self.openai_model = openai.OpenAI()
+        self.model = model
 
-    def embed_query(
-        self, text: str, model: str = "text-embedding-ada-002", **kwargs: Any
-    ) -> list[float]:
-        response = self.model.embeddings.create(input=text, model=model, **kwargs)
+    def embed_query(self, text: str, **kwargs: Any) -> list[float]:
+        response = self.openai_model.embeddings.create(
+            input=text, model=self.model, **kwargs
+        )
         return response.data[0].embedding

--- a/src/neo4j_genai/embeddings/sentence_transformers.py
+++ b/src/neo4j_genai/embeddings/sentence_transformers.py
@@ -1,3 +1,18 @@
+#  Copyright (c) "Neo4j"
+#  Neo4j Sweden AB [https://neo4j.com]
+#  #
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  #
+#      https://www.apache.org/licenses/LICENSE-2.0
+#  #
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from typing import Any
 
 import numpy as np

--- a/tests/unit/embeddings/test_sentence_transformers.py
+++ b/tests/unit/embeddings/test_sentence_transformers.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from neo4j_genai.embedder import Embedder
-from neo4j_genai.embeddings import SentenceTransformerEmbeddings
+from neo4j_genai.embeddings.sentence_transformers import SentenceTransformerEmbeddings
 
 
 @patch("sentence_transformers.SentenceTransformer")


### PR DESCRIPTION
# Description

This PR fixes a few issues regarding using the package's `OpenAIEmbedding` class:

- Allow embedding model name to be specified correctly and used
- Removed sentence_transformers from `embeddings/__init__.py` to avoid `ImportError` if sentence_transformers` package is not installed, which is meant to be an optional dependency.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [x] E2E tests have been updated
- [x] Examples have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
