### PR TITLE
add custom prompt option to text2cypher, tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # @neo4j/neo4j-genai-python
 
 ## Next
+
+### Added
 - Add optional custom_prompt arg to the Text2CypherRetriever class.
   
 ## 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # @neo4j/neo4j-genai-python
 
 ## Next
-
+- Add optional custom_prompt arg to the Text2CypherRetriever class.
+  
 ## 0.3.1
 
 ### Fixed

--- a/src/neo4j_genai/types.py
+++ b/src/neo4j_genai/types.py
@@ -240,3 +240,4 @@ class Text2CypherRetrieverModel(BaseModel):
     neo4j_schema_model: Optional[Neo4jSchemaModel] = None
     examples: Optional[list[str]] = None
     result_formatter: Optional[Callable[[neo4j.Record], RetrieverResultItem]] = None
+    custom_prompt: Optional[str] = None

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -64,7 +64,7 @@ def test_t2c_retriever_invalid_neo4j_schema(
     _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
 ) -> None:
     with pytest.raises(RetrieverInitializationError) as exc_info:
-        Text2CypherRetriever(driver=driver, llm=llm, neo4j_schema=42)
+        Text2CypherRetriever(driver=driver, llm=llm, neo4j_schema=42)  # type: ignore
 
     assert "neo4j_schema" in str(exc_info.value)
     assert "Input should be a valid string" in str(exc_info.value)

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -64,7 +64,11 @@ def test_t2c_retriever_invalid_neo4j_schema(
     _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
 ) -> None:
     with pytest.raises(RetrieverInitializationError) as exc_info:
-        Text2CypherRetriever(driver=driver, llm=llm, neo4j_schema=42)  # type: ignore
+        Text2CypherRetriever(
+            driver=driver,
+            llm=llm,
+            neo4j_schema=42,  # type: ignore[arg-type, unused-ignore]
+        )
 
     assert "neo4j_schema" in str(exc_info.value)
     assert "Input should be a valid string" in str(exc_info.value)
@@ -93,7 +97,7 @@ def test_t2c_retriever_invalid_search_examples(
             driver=driver,
             llm=llm,
             neo4j_schema="dummy-text",
-            examples=42,  # type: ignore
+            examples=42,  # type: ignore[arg-type, unused-ignore]
         )
 
     assert "examples" in str(exc_info.value)
@@ -114,8 +118,8 @@ def test_t2c_retriever_happy_path(
     retriever = Text2CypherRetriever(
         driver=driver, llm=llm, neo4j_schema=neo4j_schema, examples=examples
     )
-    retriever.llm.invoke.return_value = LLMResponse(content=t2c_query)
-    retriever.driver.execute_query.return_value = (  # type: ignore
+    llm.invoke.return_value = LLMResponse(content=t2c_query)
+    driver.execute_query.return_value = (
         [neo4j_record],
         None,
         None,
@@ -127,8 +131,8 @@ def test_t2c_retriever_happy_path(
         query=query_text,
     )
     retriever.search(query_text=query_text)
-    retriever.llm.invoke.assert_called_once_with(prompt)
-    retriever.driver.execute_query.assert_called_once_with(query_=t2c_query)  # type: ignore
+    llm.invoke.assert_called_once_with(prompt)
+    driver.execute_query.assert_called_once_with(query_=t2c_query)
 
 
 @patch("neo4j_genai.retrievers.Text2CypherRetriever._verify_version")
@@ -193,7 +197,7 @@ def test_t2c_retriever_initialization_with_custom_prompt(
     prompt = "This is a custom prompt."
     with caplog.at_level(logging.DEBUG):
         retriever = Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=prompt)
-        retriever.driver.execute_query.return_value = (
+        driver.execute_query.return_value = (
             [neo4j_record],
             None,
             None,
@@ -224,7 +228,7 @@ def test_t2c_retriever_initialization_with_custom_prompt_and_schema_and_examples
             examples=examples,
         )
 
-        retriever.driver.execute_query.return_value = (
+        driver.execute_query.return_value = (
             [neo4j_record],
             None,
             None,
@@ -239,6 +243,10 @@ def test_t2c_retriever_invalid_custom_prompt_type(
     _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
 ) -> None:
     with pytest.raises(RetrieverInitializationError) as exc_info:
-        Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=42)  # type: ignore
+        Text2CypherRetriever(
+            driver=driver,
+            llm=llm,
+            custom_prompt=42,  # type: ignore[arg-type, unused-ignore]
+        )
 
     assert "Input should be a valid string" in str(exc_info.value)

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -239,6 +239,6 @@ def test_t2c_retriever_invalid_custom_prompt_type(
     _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
 ) -> None:
     with pytest.raises(RetrieverInitializationError) as exc_info:
-        Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=42)
+        Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=42)  # type: ignore
 
     assert "Input should be a valid string" in str(exc_info.value)

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -128,7 +128,7 @@ def test_t2c_retriever_happy_path(
     )
     retriever.search(query_text=query_text)
     retriever.llm.invoke.assert_called_once_with(prompt)
-    retriever.driver.execute_query.assert_called_once_with(query_=t2c_query)
+    retriever.driver.execute_query.assert_called_once_with(query_=t2c_query)  # type: ignore
 
 
 @patch("neo4j_genai.retrievers.Text2CypherRetriever._verify_version")

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -115,7 +115,7 @@ def test_t2c_retriever_happy_path(
         driver=driver, llm=llm, neo4j_schema=neo4j_schema, examples=examples
     )
     retriever.llm.invoke.return_value = LLMResponse(content=t2c_query)
-    retriever.driver.execute_query.return_value = (
+    retriever.driver.execute_query.return_value = (  # type: ignore
         [neo4j_record],
         None,
         None,

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -93,7 +93,7 @@ def test_t2c_retriever_invalid_search_examples(
             driver=driver,
             llm=llm,
             neo4j_schema="dummy-text",
-            examples=42,
+            examples=42,  # type: ignore
         )
 
     assert "examples" in str(exc_info.value)

--- a/tests/unit/retrievers/test_text2cypher.py
+++ b/tests/unit/retrievers/test_text2cypher.py
@@ -64,7 +64,7 @@ def test_t2c_retriever_invalid_neo4j_schema(
     _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
 ) -> None:
     with pytest.raises(RetrieverInitializationError) as exc_info:
-        Text2CypherRetriever(driver=driver, llm=llm, neo4j_schema=42)  # type: ignore
+        Text2CypherRetriever(driver=driver, llm=llm, neo4j_schema=42)
 
     assert "neo4j_schema" in str(exc_info.value)
     assert "Input should be a valid string" in str(exc_info.value)
@@ -93,7 +93,7 @@ def test_t2c_retriever_invalid_search_examples(
             driver=driver,
             llm=llm,
             neo4j_schema="dummy-text",
-            examples=42,  # type: ignore
+            examples=42,
         )
 
     assert "examples" in str(exc_info.value)
@@ -115,7 +115,7 @@ def test_t2c_retriever_happy_path(
         driver=driver, llm=llm, neo4j_schema=neo4j_schema, examples=examples
     )
     retriever.llm.invoke.return_value = LLMResponse(content=t2c_query)
-    retriever.driver.execute_query.return_value = (  # type: ignore
+    retriever.driver.execute_query.return_value = (
         [neo4j_record],
         None,
         None,
@@ -128,7 +128,7 @@ def test_t2c_retriever_happy_path(
     )
     retriever.search(query_text=query_text)
     retriever.llm.invoke.assert_called_once_with(prompt)
-    retriever.driver.execute_query.assert_called_once_with(query_=t2c_query)  # type: ignore
+    retriever.driver.execute_query.assert_called_once_with(query_=t2c_query)
 
 
 @patch("neo4j_genai.retrievers.Text2CypherRetriever._verify_version")
@@ -193,7 +193,7 @@ def test_t2c_retriever_initialization_with_custom_prompt(
     prompt = "This is a custom prompt."
     with caplog.at_level(logging.DEBUG):
         retriever = Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=prompt)
-        retriever.driver.execute_query.return_value = (  # type: ignore
+        retriever.driver.execute_query.return_value = (
             [neo4j_record],
             None,
             None,
@@ -224,7 +224,7 @@ def test_t2c_retriever_initialization_with_custom_prompt_and_schema_and_examples
             examples=examples,
         )
 
-        retriever.driver.execute_query.return_value = (  # type: ignore
+        retriever.driver.execute_query.return_value = (
             [neo4j_record],
             None,
             None,
@@ -232,3 +232,13 @@ def test_t2c_retriever_initialization_with_custom_prompt_and_schema_and_examples
         retriever.search(query_text="test")
 
     assert f"Text2CypherRetriever prompt: {prompt}" in caplog.text
+
+
+@patch("neo4j_genai.retrievers.Text2CypherRetriever._verify_version")
+def test_t2c_retriever_invalid_custom_prompt_type(
+    _verify_version_mock: MagicMock, driver: MagicMock, llm: MagicMock
+) -> None:
+    with pytest.raises(RetrieverInitializationError) as exc_info:
+        Text2CypherRetriever(driver=driver, llm=llm, custom_prompt=42)
+
+    assert "Input should be a valid string" in str(exc_info.value)


### PR DESCRIPTION
# Description

Add an option to provide a custom prompt to the Text2Cypher Retriever. Doing so will ignore any provided graph schema or examples.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update
- [ ] Project configuration change

## Complexity

Low

Complexity:

## How Has This Been Tested?
- [x] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

no E2E tests needed, no examples written, no new files created

- [x] Documentation has been updated
- [x] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [x] CHANGELOG.md updated if appropriate
