### PR TITLE
Resolve issue with GitHub Actions runner running out of disk space

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -1,10 +1,6 @@
 name: 'Neo4j-GenAI PR E2E Tests'
 
 on:
-  push:
-    branches:
-      - main
-      - fix-out-of-space-error-on-gh-actions
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -18,10 +18,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       matrix:
-        python-version: ['3.8', '3.12']
-#        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:
           - 5
         neo4j-edition:
@@ -56,6 +54,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - name: Docker Prune
+        run: |
+          docker system prune -af
+          docker volume prune -f
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -1,6 +1,10 @@
 name: 'Neo4j-GenAI PR E2E Tests'
 
 on:
+  push:
+    branches:
+      - main
+      - fix-out-of-space-error-on-gh-actions
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
@@ -14,8 +18,10 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.12']
+#        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:
           - 5
         neo4j-edition:
@@ -68,6 +74,8 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Check disk space after cleanup
+        run: df -h
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -18,6 +18,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 3
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -18,7 +18,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 3
+      max-parallel: 6
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -2,7 +2,7 @@ name: 'Neo4j-GenAI Scheduled E2E Tests'
 
 on:
   schedule:
-    - cron:  '0 */3 * * *'  # Runs every 3 hours
+    - cron:  '0 6,9,12,15,18 * * 1-5'  # Runs every 3 hours daytime on working days
   push:
     branches:
       - main

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -1,28 +1,23 @@
-name: 'Neo4j-GenAI PR E2E Tests'
+name: 'Neo4j-GenAI Scheduled E2E Tests'
 
 on:
+  schedule:
+    - cron:  '0 */3 * * *'  # Runs every 3 hours
   push:
     branches:
       - main
-      - fix-out-of-space-error-on-gh-actions
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches:
-      - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 6
       matrix:
-        python-version: ['3.8', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:
           - 5
         neo4j-edition:
+          - community
           - enterprise
     services:
       t2v-transformers:


### PR DESCRIPTION
# Description

- For E2E tests, prune docker images before installing dependencies to reduce disk file usage
- Adds a new workflow for running E2E tests on main every 3 hours
- Reduces scope (Python versions and Neo4j community Docker image) of PR E2E tests 


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [x] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [x] E2E tests
- [x] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
