### PR TITLE
Make GraphRAG search's query backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 ### Added
 - Add optional custom_prompt arg to the Text2CypherRetriever class.
-  
+
+### Changed
+- `GraphRAG.search` method first parameter has been renamed `query_text` (was `query`) for consistency with the retrievers interface.
+- Made `GraphRAG.search` method backwards compatible with the query parameter, raising warnings to encourage using query_text instead.
+
 ## 0.3.1
 
 ### Fixed
 -   Corrected initialization to allow specifying the embedding model name.
 -   Removed sentence_transformers from embeddings/__init__.py to avoid ImportError when the package is not installed.
-
-### Changed
-- `GraphRAG.search` method first parameter has been renamed `query_text` (was `query`) for consistency with the retrievers interface.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ rag = GraphRAG(retriever=retriever, llm=llm)
 
 # Query the graph
 query_text = "How do I do similarity search in Neo4j?"
-response = rag.search(query=query_text, retriever_config={"top_k": 5})
+response = rag.search(query_text=query_text, retriever_config={"top_k": 5})
 print(response.answer)
 ```
 

--- a/src/neo4j_genai/generation/graphrag.py
+++ b/src/neo4j_genai/generation/graphrag.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any, Optional
 
 from pydantic import ValidationError
@@ -53,10 +54,11 @@ class GraphRAG:
 
     def search(
         self,
-        query_text: str,
+        query_text: str = "",
         examples: str = "",
         retriever_config: Optional[dict[str, Any]] = None,
         return_context: bool = False,
+        query: Optional[str] = None,
     ) -> RagResultModel:
         """This method performs a full RAG search:
         1. Retrieval: context retrieval
@@ -69,12 +71,28 @@ class GraphRAG:
             retriever_config (Optional[dict]): Parameters passed to the retriever
                 search method; e.g.: top_k
             return_context (bool): Whether to return the retriever result (default: False)
+            query (Optional[str]): The user question. Will be deprecated in favor of query_text.
 
         Returns:
             RagResultModel: The LLM-generated answer
 
         """
         try:
+            if query is not None:
+                if query_text:
+                    warnings.warn(
+                        "Both 'query' and 'query_text' are provided, 'query_text' will be used.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+            elif isinstance(query, str):
+                warnings.warn(
+                    "'query' is deprecated and will be removed in a future version, please use 'query_text' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                query_text = query
+
             validated_data = RagSearchModel(
                 query_text=query_text,
                 examples=examples,


### PR DESCRIPTION
# Description
https://github.com/neo4j/neo4j-genai-python/pull/89 A previous PR removed the `query` argument from `GraphRAG`'s `.search()` which is a breaking change. This PR allows the argument `query` to still be used, but raises warnings for the user to start using `query_text`.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [x] Unit tests
- [x] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [x] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
