### PR TITLE
Updated cadence of scheduled E2E tests and clear poetry cache during them

### DIFF
--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -60,7 +60,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Show disk usage after Python installation
         run: |
-          df -h
+          df -h $GITHUB_WORKSPACE
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
@@ -69,7 +69,7 @@ jobs:
           installer-parallel: true
       - name: Show disk usage after Poetry installation
         run: |
-          df -h
+          df -h $GITHUB_WORKSPACE
       - name: Set Python version for Poetry
         run: poetry env use python${{ matrix.python-version }}
       - name: Load cached venv
@@ -80,18 +80,18 @@ jobs:
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Show disk usage after venv cache retrieval
         run: |
-          df -h
+          df -h $GITHUB_WORKSPACE
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-cache --with dev
       - name: Show disk usage after dependency installation
         run: |
-          df -h
+          df -h $GITHUB_WORKSPACE
       - name: Clear Poetry cache
         run: poetry cache clear --all .
       - name: Show disk usage after Poetry installation
         run: |
-          df -h
+          df -h $GITHUB_WORKSPACE
       - name: Wait for Weaviate to start
         shell: bash
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -14,7 +14,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
       matrix:
         python-version: ['3.8', '3.12']
         neo4j-version:

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -58,12 +58,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Show disk usage after Python installation
+        run: |
+          df -h
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+      - name: Show disk usage after Poetry installation
+        run: |
+          df -h
       - name: Set Python version for Poetry
         run: poetry env use python${{ matrix.python-version }}
       - name: Load cached venv
@@ -72,9 +78,15 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Show disk usage after venv cache retrieval
+        run: |
+          df -h
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
+      - name: Show disk usage after dependency installation
+        run: |
+          df -h
       - name: Install root project
         run: poetry install --no-interaction
       - name: Install dependencies

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -58,18 +58,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Show disk usage after Python installation
-        run: |
-          df -h $GITHUB_WORKSPACE
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
-      - name: Show disk usage after Poetry installation
-        run: |
-          df -h $GITHUB_WORKSPACE
       - name: Set Python version for Poetry
         run: poetry env use python${{ matrix.python-version }}
       - name: Load cached venv
@@ -78,20 +72,14 @@ jobs:
         with:
           path: .venv
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-      - name: Show disk usage after venv cache retrieval
-        run: |
-          df -h $GITHUB_WORKSPACE
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-cache --with dev
-      - name: Show disk usage after dependency installation
-        run: |
-          df -h $GITHUB_WORKSPACE
       - name: Clear Poetry cache
         run: poetry cache clear --all .
       - name: Show disk usage after Poetry installation
         run: |
-          df -h $GITHUB_WORKSPACE
+          df -h
       - name: Wait for Weaviate to start
         shell: bash
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -83,19 +83,15 @@ jobs:
           df -h
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction --no-cache --with dev
       - name: Show disk usage after dependency installation
         run: |
           df -h
       - name: Clear Poetry cache
         run: poetry cache clear --all .
-      - name: Show disk usage after Poetry cache clear
+      - name: Show disk usage after Poetry installation
         run: |
           df -h
-      - name: Install root project
-        run: poetry install --no-interaction
-      - name: Install dependencies
-        run: poetry install --with dev
       - name: Wait for Weaviate to start
         shell: bash
         run: |

--- a/.github/workflows/pr-e2e-tests.yaml
+++ b/.github/workflows/pr-e2e-tests.yaml
@@ -14,7 +14,7 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         python-version: ['3.8', '3.12']
         neo4j-version:
@@ -85,6 +85,11 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
       - name: Show disk usage after dependency installation
+        run: |
+          df -h
+      - name: Clear Poetry cache
+        run: poetry cache clear --all .
+      - name: Show disk usage after Poetry cache clear
         run: |
           df -h
       - name: Install root project

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -2,7 +2,7 @@ name: 'Neo4j-GenAI Scheduled E2E Tests'
 
 on:
   schedule:
-    - cron:  '0 6,9,12,15,18 * * 1-5'  # Runs every 3 hours daytime on working days
+    - cron:  '0 6 * * 1-5'  # Runs at 6am on working days
   push:
     branches:
       - main

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -72,11 +72,12 @@ jobs:
           key: ${{ runner.os }}-venv-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      - name: Install root project
-        run: poetry install --no-interaction
-      - name: Install dependencies
-        run: poetry install --with dev
+        run: poetry install --no-interaction --no-cache --with dev
+      - name: Clear Poetry cache
+        run: poetry cache clear --all .
+      - name: Show disk usage after Poetry installation
+        run: |
+          df -h
       - name: Wait for Weaviate to start
         shell: bash
         run: |

--- a/.github/workflows/scheduled-e2e-tests.yaml
+++ b/.github/workflows/scheduled-e2e-tests.yaml
@@ -11,7 +11,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 6
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         neo4j-version:


### PR DESCRIPTION
# Description

- Updates scheduled CI/CD E2E tests to run only once every working day at 6 am.
- Clears Poetry cache when installing dependencies during CI/CD E2E tests in order to free up disk space.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
