### PR TITLE
Fixed query parameter bug in GraphRAG class

### DIFF
--- a/src/neo4j_genai/generation/graphrag.py
+++ b/src/neo4j_genai/generation/graphrag.py
@@ -85,13 +85,13 @@ class GraphRAG:
                         DeprecationWarning,
                         stacklevel=2,
                     )
-            elif isinstance(query, str):
-                warnings.warn(
-                    "'query' is deprecated and will be removed in a future version, please use 'query_text' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                query_text = query
+                elif isinstance(query, str):
+                    warnings.warn(
+                        "'query' is deprecated and will be removed in a future version, please use 'query_text' instead.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    query_text = query
 
             validated_data = RagSearchModel(
                 query_text=query_text,


### PR DESCRIPTION
# Description

Fixes a bug when using  the `query` parameter with the `GraphRAG` class. Previously this parameter would have not been used and an error would have been raised.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Project configuration change

## Complexity

Complexity: Low

## How Has This Been Tested?
- [X] Unit tests
- [X] E2E tests
- [X] Manual tests

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [X] Unit tests have been updated
- [ ] E2E tests have been updated
- [ ] Examples have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
- [ ] CHANGELOG.md updated if appropriate
